### PR TITLE
Fix erpnext image upload error

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -2419,8 +2419,7 @@ def upload_file_guest():
 		from frappe.utils.file_manager import save_file
 		import uuid
 		
-		# Temporarily set session user to Administrator for file operations
-		frappe.set_user("Administrator")
+		# No need to set user to Administrator since guest file upload is enabled in desk settings
 		
 		if 'file' not in frappe.request.files:
 			frappe.throw(_("No file was uploaded"))
@@ -2474,9 +2473,5 @@ def upload_file_guest():
 			user_error = "File upload failed. Please try again."
 		
 		frappe.throw(_(user_error))
-	
-	finally:
-		# Reset user session
-		frappe.set_user("Guest")
 
 

--- a/education/hooks.py
+++ b/education/hooks.py
@@ -193,9 +193,10 @@ after_install = "education.install.after_install"
 # }
 
 # Guest permissions for file uploads in student applications
-has_permission = {
-	"File": "education.education.api.has_file_permission",
-}
+# Removed custom file permission handler as guest file upload is now enabled in desk settings
+# has_permission = {
+# 	"File": "education.education.api.has_file_permission",
+# }
 
 # DocType Class
 # ---------------


### PR DESCRIPTION
Remove custom file permission handler and user switching for guest file uploads to resolve 500 errors, as guest file uploads are now handled by desk settings.