### PR TITLE
Fix ethiopian calendar date picker reset

### DIFF
--- a/education/www/apply.html
+++ b/education/www/apply.html
@@ -1885,6 +1885,14 @@
                     this.ethiopianMonth = '';
                     this.ethiopianDay = '';
                     
+                    // Properly reinitialize Ethiopian calendar data
+                    const currentYear = new Date().getFullYear() - 8; // Approximate EC
+                    this.ethiopianYears = [];
+                    for (let y = currentYear; y >= 1980; y--) {
+                        this.ethiopianYears.push(y);
+                    }
+                    this.updateEthiopianDays();
+                    
                     // Reset other fields
                     this.nationalIdError = '';
                 },
@@ -1935,9 +1943,13 @@
                     // Reset other fields
                     this.nationalIdError = '';
                     
-                    // Initialize Ethiopian calendar data
+                    // Properly reinitialize Ethiopian calendar data
+                    const currentYear = new Date().getFullYear() - 8; // Approximate EC
                     this.ethiopianYears = [];
-                    this.ethiopianDays = [];
+                    for (let y = currentYear; y >= 1980; y--) {
+                        this.ethiopianYears.push(y);
+                    }
+                    this.updateEthiopianDays();
                     
                     this.showNotification('Ready to add another child. Guardian and address information preserved.', 'success', 3000);
                 },


### PR DESCRIPTION
Reinitialize Ethiopian calendar date picker data to fix empty year/day selectors after adding a new child or starting a new application.

Previously, the `ethiopianYears` and `ethiopianDays` arrays were reset to empty but not repopulated in `addAnotherChild()` and `resetForm()`, leading to blank dropdowns. This change ensures `updateEthiopianDays()` is called and `ethiopianYears` are correctly populated.

---
<a href="https://cursor.com/background-agent?bcId=bc-13aebcb0-b38e-472d-992f-24d17be4ba11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13aebcb0-b38e-472d-992f-24d17be4ba11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>