### PR TITLE
Create student result entry page

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _
 from frappe.email.doctype.email_group.email_group import add_subscribers
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import cstr, flt, getdate
+from frappe.utils import cstr, cint, flt, getdate
 from frappe.utils.dateutils import get_dates_from_timegrain
 
 
@@ -1301,7 +1301,15 @@ def create_student_term_subject_result(result_data):
 		if missing:
 			frappe.throw(_("Missing required values: {0}").format(", ".join(missing)))
 
-		doc = frappe.new_doc("Student Term Subject Result")
+		doc_name = result_data.get("name")
+		if doc_name:
+			doc = frappe.get_doc("Student Term Subject Result", doc_name)
+			if doc.docstatus != 0:
+				frappe.throw(_("Only draft Student Term Subject Results can be updated."))
+		else:
+			doc = frappe.new_doc("Student Term Subject Result")
+			doc.naming_series = result_data.get("naming_series") or "STSR-.YYYY.-"
+
 		doc.student = result_data.get("student")
 		doc.student_name = result_data.get("student_name")
 		doc.academic_year = result_data.get("academic_year")
@@ -1315,8 +1323,12 @@ def create_student_term_subject_result(result_data):
 		if result_data.get("examiner"):
 			doc.examiner = result_data.get("examiner")
 
-		doc.insert(ignore_permissions=True)
-		if frappe.utils.cint(result_data.get("submit", 1)):
+		if doc_name:
+			doc.save(ignore_permissions=True)
+		else:
+			doc.insert(ignore_permissions=True)
+
+		if cint(result_data.get("submit")):
 			doc.submit()
 
 		return {
@@ -1327,6 +1339,24 @@ def create_student_term_subject_result(result_data):
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), "Create Student Term Subject Result API Error")
 		frappe.throw(str(e))
+
+
+@frappe.whitelist()
+def get_student_group_scores(student_group, academic_year, semester, subject, exam):
+	filters = {
+		"student_group": student_group,
+		"academic_year": academic_year,
+		"semester": semester,
+		"subject": subject,
+		"exam": exam,
+		"docstatus": 0,
+	}
+	return frappe.get_all(
+		"Student Term Subject Result",
+		filters=filters,
+		fields=["name", "student", "student_name", "score", "max_score"],
+		order_by="student asc",
+	)
 
 
 @frappe.whitelist()

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -1276,6 +1276,60 @@ def create_and_submit_term_subject_result(data):
 
 
 @frappe.whitelist()
+def create_student_term_subject_result(result_data):
+	"""Create and submit a Student Term Subject Result document from frontend payload."""
+	try:
+		if isinstance(result_data, str):
+			result_data = frappe.parse_json(result_data)
+
+		required_fields = [
+			"student",
+			"academic_year",
+			"semester",
+			"subject",
+			"student_group",
+			"grade",
+			"exam",
+			"score",
+			"max_score",
+		]
+		missing = [
+			field.replace("_", " ").title()
+			for field in required_fields
+			if result_data.get(field) in (None, "", [])
+		]
+		if missing:
+			frappe.throw(_("Missing required values: {0}").format(", ".join(missing)))
+
+		doc = frappe.new_doc("Student Term Subject Result")
+		doc.student = result_data.get("student")
+		doc.student_name = result_data.get("student_name")
+		doc.academic_year = result_data.get("academic_year")
+		doc.semester = result_data.get("semester")
+		doc.subject = result_data.get("subject")
+		doc.student_group = result_data.get("student_group") or result_data.get("section")
+		doc.grade = result_data.get("grade")
+		doc.exam = result_data.get("exam")
+		doc.score = flt(result_data.get("score"))
+		doc.max_score = flt(result_data.get("max_score"))
+		if result_data.get("examiner"):
+			doc.examiner = result_data.get("examiner")
+
+		doc.insert(ignore_permissions=True)
+		if frappe.utils.cint(result_data.get("submit", 1)):
+			doc.submit()
+
+		return {
+			"status": "success",
+			"name": doc.name,
+			"docstatus": doc.docstatus,
+		}
+	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), "Create Student Term Subject Result API Error")
+		frappe.throw(str(e))
+
+
+@frappe.whitelist()
 def get_student_term_results(student, academic_year, semester=None):
 	"""Get all term subject results for a student"""
 	try:

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -1275,7 +1275,7 @@ def create_and_submit_term_subject_result(data):
 		frappe.throw(str(e))
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def create_student_term_subject_result(result_data):
 	"""Create and submit a Student Term Subject Result document from frontend payload."""
 	try:
@@ -1341,7 +1341,7 @@ def create_student_term_subject_result(result_data):
 		frappe.throw(str(e))
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_student_group_scores(student_group, academic_year, semester, subject, exam):
 	filters = {
 		"student_group": student_group,

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -1342,6 +1342,37 @@ def create_student_term_subject_result(result_data):
 
 
 @frappe.whitelist(allow_guest=True)
+def save_student_term_subject_results(entries):
+	try:
+		entries = frappe.parse_json(entries)
+		if not isinstance(entries, list):
+			entries = [entries]
+
+		success, failed = [], []
+
+		for entry in entries:
+			try:
+				doc = _save_single_student_result(entry)
+				success.append(
+					{
+						"name": doc.name,
+						"student": doc.student,
+						"subject": doc.subject,
+						"exam": doc.exam,
+						"score": doc.score,
+					}
+				)
+			except Exception as err:
+				failed.append({"entry": entry, "error": str(err)})
+
+		frappe.db.commit()
+		return {"success": success, "failed": failed}
+	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), "Bulk Student Term Subject Result Save Error")
+		frappe.throw(str(e))
+
+
+@frappe.whitelist(allow_guest=True)
 def get_student_group_scores(student_group, academic_year, semester, subject, exam):
 	filters = {
 		"student_group": student_group,
@@ -1357,6 +1388,52 @@ def get_student_group_scores(student_group, academic_year, semester, subject, ex
 		fields=["name", "student", "student_name", "score", "max_score"],
 		order_by="student asc",
 	)
+
+
+def _save_single_student_result(data):
+	required_fields = [
+		"student",
+		"academic_year",
+		"semester",
+		"subject",
+		"student_group",
+		"grade",
+		"exam",
+		"score",
+		"max_score",
+	]
+
+	missing = [field for field in required_fields if data.get(field) in (None, "")]
+	if missing:
+		raise frappe.ValidationError(_("Missing values: {0}").format(", ".join(missing)))
+
+	doc_name = data.get("name")
+	if doc_name:
+		doc = frappe.get_doc("Student Term Subject Result", doc_name)
+		if doc.docstatus != 0:
+			raise frappe.ValidationError(_("Cannot update submitted Student Term Subject Result: {0}").format(doc_name))
+	else:
+		doc = frappe.new_doc("Student Term Subject Result")
+		doc.naming_series = data.get("naming_series") or "STSR-.YYYY.-"
+
+	doc.student = data.get("student")
+	doc.student_name = data.get("student_name")
+	doc.academic_year = data.get("academic_year")
+	doc.semester = data.get("semester")
+	doc.subject = data.get("subject")
+	doc.student_group = data.get("student_group") or data.get("section")
+	doc.grade = data.get("grade")
+	doc.exam = data.get("exam")
+	doc.score = flt(data.get("score"))
+	doc.max_score = flt(data.get("max_score"))
+	doc.examiner = data.get("examiner")
+
+	if doc.is_new():
+		doc.insert(ignore_permissions=True)
+	else:
+		doc.save(ignore_permissions=True)
+
+	return doc
 
 
 @frappe.whitelist()

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -365,7 +365,7 @@
 			allFailed: "Unable to submit any of the queued scores."
 		};
 
-		const csrfToken = "{{ csrf_token | default('', true) }}";
+		let csrfToken = "{{ csrf_token | default('', true) }}";
 		const wubetBoot = {{ wubet_boot | safe }};
 		const elements = {};
 		const examScoreMap = {};
@@ -450,6 +450,21 @@
 			elements.logButton.addEventListener("click", logScores);
 			elements.submitButton.addEventListener("click", submitLoggedScores);
 			elements.clearButton.addEventListener("click", resetForm);
+		}
+
+		function getCookie(name) {
+			const value = `; ${document.cookie}`;
+			const parts = value.split(`; ${name}=`);
+			if (parts.length === 2) return parts.pop().split(";").shift();
+			return "";
+		}
+
+		function refreshCsrfToken() {
+			const cookieToken = getCookie("frappe-csrf-token");
+			if (cookieToken) {
+				csrfToken = cookieToken;
+			}
+			return csrfToken;
 		}
 
 		function logDebug(message, payload) {
@@ -1030,6 +1045,7 @@
 						<p>${escapeHtml(TEXT.someFailed)}</p>
 						<ul>${details}</ul>
 					</div>`;
+				showFeedback(TEXT.scoreSaveError, "danger");
 			}
 
 			elements.summary.innerHTML = summaryHtml;
@@ -1071,8 +1087,11 @@
 
 			if (method !== "GET") {
 				headers["Content-Type"] = "application/json";
-				if (csrfToken) {
-					headers["X-Frappe-CSRF-Token"] = csrfToken;
+				const latestToken = refreshCsrfToken();
+				if (latestToken) {
+					headers["X-Frappe-CSRF-Token"] = latestToken;
+				} else {
+					logDebug("Missing CSRF token", { method, url });
 				}
 			}
 

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -952,17 +952,23 @@
 			disableButtons(true);
 			showFeedback(TEXT.submitting, "info");
 
-			const summary = { success: [], failed: [] };
-			logDebug("Submitting queued scores", state.loggedEntries);
+			const payloadEntries = state.loggedEntries.map(entry => {
+				const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
+				return {
+					...entry,
+					name: entry.name || state.resultDocs[key] || null
+				};
+			});
 
-			for (const entry of state.loggedEntries) {
-				try {
-					await callCreateResult(entry);
-					summary.success.push(entry);
-				} catch (error) {
-					logDebug("Failed to save score", { entry, error: error.message || error });
-					summary.failed.push({ entry, error: error.message || error });
-				}
+			logDebug("Submitting queued scores", payloadEntries);
+
+			let summary = { success: [], failed: [] };
+			try {
+				const response = await callCreateResult(payloadEntries);
+				summary = response || summary;
+			} catch (error) {
+				logDebug("Failed to save batch", { error: error.message || error });
+				summary.failed = payloadEntries.map(entry => ({ entry, error: error.message || error }));
 			}
 
 			disableButtons(false);
@@ -975,46 +981,29 @@
 			elements.clearButton.disabled = isDisabled;
 		}
 
-		async function callCreateResult(entry) {
-			const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
-			const payload = {
-				name: entry.name || state.resultDocs[key],
-				naming_series: "STSR-.YYYY.-",
-				student: entry.student,
-				student_name: entry.student_name,
-				academic_year: entry.academic_year,
-				semester: entry.semester,
-				subject: entry.subject,
-				student_group: entry.student_group,
-				grade: entry.grade,
-				exam: entry.exam,
-				score: entry.score,
-				max_score: entry.max_score,
-				examiner: entry.examiner || "",
-				submit: 0
-			};
-
-			logDebug("Saving score via method", { entry, payload });
-
+		async function callCreateResult(entries) {
 			const response = await apiCall(
-				"/api/method/education.education.api.create_student_term_subject_result",
-				{ result_data: payload },
+				"/api/method/education.education.api.save_student_term_subject_results",
+				{ entries: JSON.stringify(entries) },
 				{ method: "POST" }
 			);
 
-			logDebug("Method response", { response });
+			logDebug("Method response", response);
 
-			const docName = response && response.name;
-			if (docName) {
-				state.resultDocs[key] = docName;
-				entry.name = docName;
+			(response.success || []).forEach(record => {
+				const entry = entries.find(e => e.student === record.student && e.exam === record.exam && e.subject === record.subject);
+				if (!entry) return;
+				const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
+				state.resultDocs[key] = record.name;
+				entry.name = record.name;
 				state.studentScores[entry.student] = {
 					student: entry.student,
 					student_name: entry.student_name,
 					score: entry.score,
-					docname: docName
+					docname: record.name
 				};
-			}
+			});
+
 			return response;
 		}
 

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -976,7 +976,9 @@
 		}
 
 		async function callCreateResult(entry) {
+			const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
 			const payload = {
+				name: entry.name || state.resultDocs[key],
 				naming_series: "STSR-.YYYY.-",
 				student: entry.student,
 				student_name: entry.student_name,
@@ -988,35 +990,22 @@
 				exam: entry.exam,
 				score: entry.score,
 				max_score: entry.max_score,
-				examiner: entry.examiner || ""
+				examiner: entry.examiner || "",
+				submit: 0
 			};
 
-			logDebug("Saving score", {
-				method: entry.name ? "PUT" : "POST",
-				entry,
-				payload
-			});
+			logDebug("Saving score via method", { entry, payload });
 
-			let response;
-			if (entry.name) {
-				response = await apiCall(
-					`/api/resource/Student Term Subject Result/${encodeURIComponent(entry.name)}`,
-					payload,
-					{ method: "PUT" }
-				);
-			} else {
-				const body = { doctype: "Student Term Subject Result", ...payload };
-				response = await apiCall(
-					"/api/resource/Student Term Subject Result",
-					body,
-					{ method: "POST" }
-				);
-			}
-			logDebug("API response", { entry, payload, response });
+			const response = await apiCall(
+				"/api/method/education.education.api.create_student_term_subject_result",
+				{ result_data: payload },
+				{ method: "POST" }
+			);
+
+			logDebug("Method response", { response });
 
 			const docName = response && response.name;
 			if (docName) {
-				const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
 				state.resultDocs[key] = docName;
 				entry.name = docName;
 				state.studentScores[entry.student] = {

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -332,6 +332,7 @@
 			selectSemester: "Select Semester",
 			noStudents: "No students found for the selected group.",
 			loadStudentsError: "Unable to load students. Please try again.",
+			scoreFetchError: "Unable to load existing scores.",
 			fieldRequired: "is required.",
 			maxScoreRequired: "Maximum Score is required. Select an exam to set it automatically.",
 			scoreRequired: "Score is required for logged students.",
@@ -358,6 +359,7 @@
 			loggedEntries: [],
 			students: [],
 			studentScores: {},
+			resultDocs: {},
 			lastQueuedScores: {},
 			currentGrade: { value: "", label: "" }
 		};
@@ -426,10 +428,89 @@
 		function registerListeners() {
 			elements.form.addEventListener("submit", evt => evt.preventDefault());
 			elements.studentGroup.addEventListener("change", handleStudentGroupChange);
+			elements.subject.addEventListener("change", handleContextChange);
+			elements.semester.addEventListener("change", handleContextChange);
+			elements.academicYear.addEventListener("change", handleContextChange);
 			elements.exam.addEventListener("change", handleExamChange);
 			elements.logButton.addEventListener("click", logScores);
 			elements.submitButton.addEventListener("click", submitLoggedScores);
 			elements.clearButton.addEventListener("click", resetForm);
+		}
+
+		function getScoreContextParams() {
+			return {
+				student_group: elements.studentGroup.value,
+				academic_year: elements.academicYear.value.trim(),
+				semester: elements.semester.value,
+				subject: elements.subject.value,
+				exam: elements.exam.value
+			};
+		}
+
+		function hasScoreContext() {
+			const ctx = getScoreContextParams();
+			return ctx.student_group && ctx.academic_year && ctx.semester && ctx.subject && ctx.exam;
+		}
+
+		function clearScoreState() {
+			state.studentScores = {};
+			state.resultDocs = {};
+			state.lastQueuedScores = {};
+			state.loggedEntries = [];
+			renderEntries();
+			if (elements.summary) {
+				elements.summary.style.display = "none";
+				elements.summary.innerHTML = "";
+			}
+			if (elements.studentsTableBody) {
+				elements.studentsTableBody.querySelectorAll(".score-input").forEach(input => {
+					input.value = "";
+				});
+			}
+		}
+
+		function applyScoresToInputs() {
+			if (!elements.studentsTableBody) return;
+			elements.studentsTableBody.querySelectorAll(".score-input").forEach(input => {
+				const stored = state.studentScores[input.dataset.student];
+				if (stored && typeof stored.score === "number") {
+					input.value = stored.score;
+				} else {
+					input.value = "";
+				}
+			});
+		}
+
+		async function fetchExistingScores() {
+			if (!hasScoreContext()) return;
+			const params = getScoreContextParams();
+			try {
+				const records = await apiCall(
+					"/api/method/education.education.api.get_student_group_scores",
+					params,
+					{ method: "GET" }
+				);
+				state.studentScores = {};
+				state.resultDocs = {};
+				state.lastQueuedScores = {};
+				(records || []).forEach(record => {
+					const scoreValue = parseFloat(record.score);
+					const studentId = record.student;
+					state.studentScores[studentId] = {
+						student: studentId,
+						student_name: record.student_name || "",
+						score: scoreValue,
+						docname: record.name
+					};
+					const key = buildScoreKey(studentId, params.subject, params.exam, params.academic_year, params.semester);
+					state.resultDocs[key] = record.name;
+					state.lastQueuedScores[key] = scoreValue;
+				});
+				applyScoresToInputs();
+			} catch (error) {
+				console.error("Failed to fetch existing scores", error);
+				showFeedback(TEXT.scoreFetchError, "danger");
+			}
 		}
 
 		function setDefaultValues() {
@@ -455,6 +536,7 @@
 		}
 
 		function handleStudentGroupChange(event) {
+			clearScoreState();
 			const selectedOption = event.target.selectedOptions[0];
 			const programId = selectedOption ? selectedOption.dataset.program : "";
 			const label = programLabelMap[programId] || programId || "";
@@ -463,20 +545,21 @@
 				label: label || ""
 			};
 			elements.gradeDisplay.value = label || "";
-			if (state.loggedEntries.length) {
-				state.loggedEntries = [];
-				state.lastQueuedScores = {};
-				renderEntries();
-				elements.summary.style.display = "none";
-				elements.summary.innerHTML = "";
-			}
 			loadStudentsForGroup(event.target.value);
+		}
+
+		function handleContextChange() {
+			clearScoreState();
+			if (state.students.length && hasScoreContext()) {
+				fetchExistingScores();
+			}
 		}
 
 		function handleExamChange(event) {
 			const exam = event.target.value;
 			elements.maxScore.value = exam ? (examScoreMap[exam] || "") : "";
 			updateAllScoreInputsMax();
+			handleContextChange();
 		}
 
 		function resetForm() {
@@ -484,20 +567,15 @@
 			elements.gradeDisplay.value = "";
 			state.currentGrade = { value: "", label: "" };
 			state.students = [];
-			state.studentScores = {};
-			state.lastQueuedScores = {};
-			state.loggedEntries = [];
+			clearScoreState();
 			setDefaultValues();
 			renderStudentsTable();
-			renderEntries();
 			clearFeedback();
-			elements.summary.style.display = "none";
-			elements.summary.innerHTML = "";
 		}
 
 		async function loadStudentsForGroup(studentGroup) {
 			state.students = [];
-			state.studentScores = {};
+			clearScoreState();
 			renderStudentsTable();
 
 			if (!studentGroup) {
@@ -513,12 +591,16 @@
 					{ method: "GET" }
 				);
 				state.students = students || [];
-				state.studentScores = {};
 				renderStudentsTable();
 				if (!state.students.length) {
 					showFeedback(TEXT.noStudents, "warning");
 				} else {
 					clearFeedback();
+					if (hasScoreContext()) {
+						await fetchExistingScores();
+					} else {
+						applyScoresToInputs();
+					}
 				}
 			} catch (error) {
 				console.error(error);
@@ -569,6 +651,7 @@
 			elements.studentsTableBody.querySelectorAll(".score-input").forEach(input => {
 				input.addEventListener("input", handleStudentScoreInput);
 			});
+			applyScoresToInputs();
 		}
 
 		function handleStudentScoreInput(event) {
@@ -595,10 +678,15 @@
 				input.value = max;
 			}
 
+			const ctx = getScoreContextParams();
+			const key = buildScoreKey(studentId, ctx.subject, ctx.exam, ctx.academic_year, ctx.semester);
+			const existingDoc = state.resultDocs[key];
+
 			state.studentScores[studentId] = {
 				student: studentId,
 				student_name: studentName,
-				score: numeric
+				score: numeric,
+				docname: existingDoc
 			};
 		}
 
@@ -698,6 +786,10 @@
 					student_name: item.student_name,
 					score: item.score
 				};
+				const existingDoc = item.docname || state.resultDocs[key];
+				if (existingDoc) {
+					entry.name = existingDoc;
+				}
 				upsertLoggedEntry(entry, key);
 				state.lastQueuedScores[key] = item.score;
 				newEntries.push(entry);
@@ -828,12 +920,25 @@
 		async function callCreateResult(entry) {
 			const payload = {
 				...entry,
-				submit: 1
+				submit: 0,
+				naming_series: "STSR-.YYYY.-"
 			};
-			return apiCall(
+			const response = await apiCall(
 				"/api/method/education.education.api.create_student_term_subject_result",
 				{ result_data: payload }
 			);
+			const docName = response && response.name;
+			if (docName) {
+				const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
+				state.resultDocs[key] = docName;
+				state.studentScores[entry.student] = {
+					student: entry.student,
+					student_name: entry.student_name,
+					score: entry.score,
+					docname: docName
+				};
+			}
+			return response;
 		}
 
 		function handleSubmissionSummary(summary) {
@@ -859,7 +964,7 @@
 
 			if (summary.failed.length === 0) {
 				state.loggedEntries = [];
-				state.lastQueuedScores = {};
+				syncLastQueuedScoresFromStudents();
 				renderEntries();
 				showFeedback(TEXT.allSuccess, "success");
 			} else if (summary.success.length) {
@@ -939,6 +1044,15 @@
 			state.loggedEntries.forEach(entry => {
 				const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
 				state.lastQueuedScores[key] = entry.score;
+			});
+		}
+
+		function syncLastQueuedScoresFromStudents() {
+			const ctx = getScoreContextParams();
+			state.lastQueuedScores = {};
+			Object.values(state.studentScores || {}).forEach(item => {
+				const key = buildScoreKey(item.student, ctx.subject, ctx.exam, ctx.academic_year, ctx.semester);
+				state.lastQueuedScores[key] = item.score;
 			});
 		}
 

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -1,576 +1,738 @@
-{% extends "templates/web.html" %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>{{ _("Student Result Entry") }}</title>
+	<meta name="description" content="{{ _("Quickly log exam scores and submit Student Term Subject Results.") }}">
+	<style>
+		body {
+			margin: 0;
+			font-family: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+			background-color: #f5f6fb;
+			color: #1f2933;
+		}
 
-{% block title %}{{ _("Student Result Entry") }}{% endblock %}
+		.page-shell {
+			min-height: 100vh;
+			padding: 30px 16px 60px;
+		}
 
-{% block page_content %}
-<div class="wubet-page container">
-	<div class="intro-card panel panel-default">
-		<div class="panel-heading">
-			<h3 class="panel-title">{{ _("Student Term Subject Results") }}</h3>
-		</div>
-		<div class="panel-body">
-			<p class="text-muted">
-				{{ _("Use this workspace to log scores for each student and automatically create Student Term Subject Result documents.") }}
-			</p>
+		@media (min-width: 992px) {
+			.page-shell {
+				padding-left: 40px;
+				padding-right: 40px;
+			}
+		}
+
+		.card {
+			background: #fff;
+			border-radius: 12px;
+			box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+			padding: 24px;
+			margin-bottom: 24px;
+		}
+
+		.card h2,
+		.card h3,
+		.card h4 {
+			margin-top: 0;
+			margin-bottom: 16px;
+		}
+
+		.help-list {
+			padding-left: 18px;
+			margin: 0;
+			color: #4b5563;
+		}
+
+		label {
+			font-weight: 600;
+			display: block;
+			margin-bottom: 6px;
+		}
+
+		input,
+		select {
+			width: 100%;
+			padding: 10px 12px;
+			border: 1px solid #cfd8e3;
+			border-radius: 8px;
+			font-size: 14px;
+			transition: border-color 0.2s ease, box-shadow 0.2s ease;
+		}
+
+		input:focus,
+		select:focus {
+			outline: none;
+			border-color: #2563eb;
+			box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+		}
+
+		.form-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+			gap: 16px;
+		}
+
+		.actions-row {
+			margin-top: 20px;
+			display: flex;
+			flex-wrap: wrap;
+			gap: 12px;
+		}
+
+		button {
+			border: none;
+			border-radius: 8px;
+			padding: 10px 18px;
+			font-weight: 600;
+			cursor: pointer;
+			transition: all 0.2s ease;
+		}
+
+		.btn-secondary {
+			background: #e5e7eb;
+			color: #111827;
+		}
+
+		.btn-secondary:hover {
+			background: #d1d5db;
+		}
+
+		.btn-primary {
+			background: #2563eb;
+			color: #fff;
+		}
+
+		.btn-primary:hover {
+			background: #1d4ed8;
+		}
+
+		.btn-success {
+			background: #16a34a;
+			color: #fff;
+			margin-left: auto;
+		}
+
+		.btn-success:hover {
+			background: #15803d;
+		}
+
+		.table-wrapper {
+			overflow-x: auto;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+			font-size: 14px;
+		}
+
+		th,
+		td {
+			padding: 10px 12px;
+			border-bottom: 1px solid #e5e7eb;
+			text-align: left;
+		}
+
+		th {
+			background: #f8fafc;
+			font-weight: 600;
+			text-transform: uppercase;
+			font-size: 12px;
+			letter-spacing: 0.04em;
+			color: #475569;
+		}
+
+		tbody tr:last-child td {
+			border-bottom: none;
+		}
+
+		.table-actions button {
+			background: #ef4444;
+			color: #fff;
+			padding: 5px 10px;
+			font-size: 12px;
+		}
+
+		.alert {
+			padding: 12px 16px;
+			border-radius: 8px;
+			margin-bottom: 16px;
+			font-weight: 500;
+		}
+
+		.alert-info {
+			background: #e0f2fe;
+			color: #0369a1;
+		}
+
+		.alert-success {
+			background: #ecfdf5;
+			color: #047857;
+		}
+
+		.alert-warning {
+			background: #fffbeb;
+			color: #92400e;
+		}
+
+		.alert-danger {
+			background: #fef2f2;
+			color: #b91c1c;
+		}
+
+		.small-text {
+			font-size: 12px;
+			color: #6b7280;
+		}
+	</style>
+</head>
+<body>
+	<div class="page-shell">
+		<header class="card">
+			<h2>{{ _("Student Term Subject Results") }}</h2>
+			<p>{{ _("Use this workspace to log scores for each student and automatically create records in the Student Term Subject Result doctype.") }}</p>
 			<ul class="help-list">
-				<li>{{ _("Start by selecting a Student Group to load the available students.") }}</li>
-				<li>{{ _("Log each score to the queue, review the list, and submit when you are ready.") }}</li>
-				<li>{{ _("Exam options automatically set the maximum score: First/Second Test (15), Mid Exam (30) and Final Exam (50).") }}</li>
+				<li>{{ _("Select a Student Group to load available students and auto-fill the grade.") }}</li>
+				<li>{{ _("Queue multiple scores before submitting them together.") }}</li>
+				<li>{{ _("Exam options predefine their maximum score: 15 for First/Second Test, 30 for Mid Exam, and 50 for Final Exam.") }}</li>
 			</ul>
-		</div>
-	</div>
+		</header>
 
-	<div class="panel panel-default">
-		<div class="panel-heading">
-			<h4 class="panel-title">{{ _("Score Entry") }}</h4>
-		</div>
-		<div class="panel-body">
+		<section class="card">
+			<h3>{{ _("Score Entry") }}</h3>
+			<div id="form-feedback" class="alert" style="display: none;"></div>
+
 			<form id="result-entry-form">
-				<div id="form-feedback" class="alert" style="display: none;"></div>
-
-				<div class="row">
-					<div class="col-md-4 form-group">
+				<div class="form-grid">
+					<div>
 						<label for="student-group">{{ _("Student Group") }}</label>
-						<select class="form-control" id="student-group" required>
+						<select id="student-group" required>
 							<option value="">{{ _("Select Student Group") }}</option>
 						</select>
-						<small id="student-loading" class="text-muted" style="display: none;">{{ _("Loading students...") }}</small>
+						<div id="student-loading" class="small-text" style="display: none;">{{ _("Loading students...") }}</div>
 					</div>
-					<div class="col-md-4 form-group">
+					<div>
 						<label for="student">{{ _("Student") }}</label>
-						<select class="form-control" id="student" disabled required>
+						<select id="student" disabled required>
 							<option value="">{{ _("Select Student") }}</option>
 						</select>
 					</div>
-					<div class="col-md-4 form-group">
+					<div>
 						<label for="student-name">{{ _("Student Name") }}</label>
-						<input type="text" class="form-control" id="student-name" placeholder="{{ _('Auto-filled after selecting a student') }}" readonly>
+						<input type="text" id="student-name" placeholder="{{ _('Auto-filled after selecting a student') }}" readonly>
 					</div>
 				</div>
 
-				<div class="row">
-					<div class="col-md-4 form-group">
-						<label for="grade">{{ _("Grade (Program)") }}</label>
-						<select class="form-control" id="grade" required>
+				<div class="form-grid" style="margin-top: 20px;">
+					<div>
+						<label for="grade">{{ _("Grade / Program") }}</label>
+						<select id="grade" required>
 							<option value="">{{ _("Select Grade / Program") }}</option>
 						</select>
 					</div>
-					<div class="col-md-4 form-group">
+					<div>
 						<label for="subject">{{ _("Subject") }}</label>
-						<select class="form-control" id="subject" required>
+						<select id="subject" required>
 							<option value="">{{ _("Select Subject") }}</option>
 						</select>
 					</div>
-					<div class="col-md-4 form-group">
+					<div>
 						<label for="academic-year">{{ _("Academic Year") }}</label>
-						<input type="text" class="form-control" id="academic-year">
+						<input type="text" id="academic-year">
 					</div>
 				</div>
 
-				<div class="row">
-					<div class="col-md-4 form-group">
+				<div class="form-grid" style="margin-top: 20px;">
+					<div>
 						<label for="semester">{{ _("Semester") }}</label>
-						<select class="form-control" id="semester" required></select>
+						<select id="semester" required></select>
 					</div>
-					<div class="col-md-4 form-group">
+					<div>
 						<label for="exam">{{ _("Exam") }}</label>
-						<select class="form-control" id="exam" required>
+						<select id="exam" required>
 							<option value="">{{ _("Select Exam") }}</option>
 						</select>
 					</div>
-					<div class="col-md-2 form-group">
+					<div>
 						<label for="max-score">{{ _("Maximum Score") }}</label>
-						<input type="number" class="form-control" id="max-score" readonly>
+						<input type="number" id="max-score" readonly>
 					</div>
-					<div class="col-md-2 form-group">
+					<div>
 						<label for="score">{{ _("Score") }}</label>
-						<input type="number" class="form-control" id="score" min="0" step="0.01" required>
+						<input type="number" id="score" min="0" step="0.01" required>
 					</div>
 				</div>
 
-				<div class="form-actions">
-					<button type="button" class="btn btn-default" id="clear-form-btn">{{ _("Reset Form") }}</button>
-					<button type="button" class="btn btn-primary" id="log-score-btn">
-						{{ _("Log Score") }}
-					</button>
-					<button type="button" class="btn btn-success pull-right" id="submit-scores-btn" disabled>
-						{{ _("Submit Logged Scores") }}
-					</button>
+				<div class="actions-row">
+					<button type="button" class="btn-secondary" id="clear-form-btn">{{ _("Reset Form") }}</button>
+					<button type="button" class="btn-primary" id="log-score-btn">{{ _("Log Score") }}</button>
+					<button type="button" class="btn-success" id="submit-scores-btn" disabled>{{ _("Submit Logged Scores") }}</button>
 				</div>
 			</form>
-		</div>
+		</section>
+
+		<section class="card">
+			<h3>{{ _("Queued Scores") }}</h3>
+			<div class="table-wrapper">
+				<table>
+					<thead>
+						<tr>
+							<th>{{ _("Academic Year") }}</th>
+							<th>{{ _("Semester") }}</th>
+							<th>{{ _("Student Group") }}</th>
+							<th>{{ _("Student") }}</th>
+							<th>{{ _("Student Name") }}</th>
+							<th>{{ _("Grade") }}</th>
+							<th>{{ _("Subject") }}</th>
+							<th>{{ _("Exam") }}</th>
+							<th>{{ _("Score") }}</th>
+							<th>{{ _("Max Score") }}</th>
+							<th>{{ _("Actions") }}</th>
+						</tr>
+					</thead>
+					<tbody id="logged-entries-body">
+						<tr id="no-entries-row">
+							<td colspan="11" style="text-align: center; color: #94a3b8;">
+								{{ _("No scores queued yet. Log a score to get started.") }}
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<div id="submission-summary" style="margin-top: 16px; display: none;"></div>
+		</section>
 	</div>
 
-	<div class="panel panel-default">
-		<div class="panel-heading">
-			<h4 class="panel-title">{{ _("Queued Scores") }}</h4>
-		</div>
-		<div class="panel-body table-responsive">
-			<table class="table table-bordered table-condensed">
-				<thead>
-					<tr>
-						<th>{{ _("Academic Year") }}</th>
-						<th>{{ _("Semester") }}</th>
-						<th>{{ _("Student Group") }}</th>
-						<th>{{ _("Student") }}</th>
-						<th>{{ _("Student Name") }}</th>
-						<th>{{ _("Grade") }}</th>
-						<th>{{ _("Subject") }}</th>
-						<th>{{ _("Exam") }}</th>
-						<th class="text-right">{{ _("Score") }}</th>
-						<th class="text-right">{{ _("Max Score") }}</th>
-						<th>{{ _("Actions") }}</th>
-					</tr>
-				</thead>
-				<tbody id="logged-entries-body">
-					<tr id="no-entries-row">
-						<td colspan="11" class="text-center text-muted">
-							{{ _("No scores queued yet. Log a score to get started.") }}
-						</td>
-					</tr>
-				</tbody>
-			</table>
-			<div id="submission-summary" style="display: none;"></div>
-		</div>
-	</div>
-</div>
-{% endblock %}
+	<script>
+		const TEXT = {
+			selectSemester: "{{ _('Select Semester') | escapejs }}",
+			selectStudent: "{{ _('Select Student') | escapejs }}",
+			noStudents: "{{ _('No students found for the selected group.') | escapejs }}",
+			loadStudentsError: "{{ _('Unable to load students. Please try again.') | escapejs }}",
+			fieldRequired: "{{ _('is required.') | escapejs }}",
+			maxScoreRequired: "{{ _('Maximum Score is required. Select an exam to set it automatically.') | escapejs }}",
+			scoreRequired: "{{ _('Score is required.') | escapejs }}",
+			scoreLimit: "{{ _('Score cannot exceed Maximum Score.') | escapejs }}",
+			entryQueued: "{{ _('Score added to the queue. Remember to submit logged scores.') | escapejs }}",
+			entryRemoved: "{{ _('Entry removed.') | escapejs }}",
+			noEntriesSubmit: "{{ _('No scores to submit.') | escapejs }}",
+			submitting: "{{ _('Submitting scores...') | escapejs }}",
+			submittedTemplate: "{{ _('Submitted {0} score(s) successfully.') | escapejs }}",
+			someFailed: "{{ _('Some submissions failed:') | escapejs }}",
+			allSuccess: "{{ _('All scores were submitted successfully.') | escapejs }}",
+			someFailedSummary: "{{ _('Some scores failed to submit. Please review the messages below.') | escapejs }}",
+			allFailed: "{{ _('Unable to submit any of the queued scores.') | escapejs }}"
+		};
 
-{% block style %}
-<style>
-	.wubet-page .panel {
-		box-shadow: none;
-	}
-	.wubet-page .help-list {
-		margin-bottom: 0;
-	}
-	.wubet-page .form-actions {
-		display: flex;
-		gap: 10px;
-		align-items: center;
-		margin-top: 15px;
-	}
-	.wubet-page .form-actions .btn {
-		min-width: 140px;
-	}
-	.wubet-page .table td {
-		vertical-align: middle;
-	}
-	.wubet-page .remove-entry-btn {
-		min-width: 80px;
-	}
-	#submission-summary .alert {
-		margin-bottom: 0;
-	}
-</style>
-{% endblock %}
+		const state = { loggedEntries: [] };
+		const wubetBoot = {{ wubet_boot | safe }};
+		const elements = {};
+		const examScoreMap = {};
 
-{% block script %}
-<script>
-	const wubetBoot = {{ wubet_boot | safe }};
-	const state = {
-		loggedEntries: []
-	};
-
-	const elements = {};
-	const examScoreMap = {};
-
-	document.addEventListener("DOMContentLoaded", () => {
-		cacheElements();
-		populateStaticSelects();
-		registerListeners();
-		setDefaultValues();
-	});
-
-	function cacheElements() {
-		elements.form = document.getElementById("result-entry-form");
-		elements.feedback = document.getElementById("form-feedback");
-		elements.studentGroup = document.getElementById("student-group");
-		elements.student = document.getElementById("student");
-		elements.studentName = document.getElementById("student-name");
-		elements.grade = document.getElementById("grade");
-		elements.subject = document.getElementById("subject");
-		elements.academicYear = document.getElementById("academic-year");
-		elements.semester = document.getElementById("semester");
-		elements.exam = document.getElementById("exam");
-		elements.maxScore = document.getElementById("max-score");
-		elements.score = document.getElementById("score");
-		elements.logButton = document.getElementById("log-score-btn");
-		elements.submitButton = document.getElementById("submit-scores-btn");
-		elements.clearButton = document.getElementById("clear-form-btn");
-		elements.entriesBody = document.getElementById("logged-entries-body");
-		elements.noEntriesRow = document.getElementById("no-entries-row");
-		elements.studentLoading = document.getElementById("student-loading");
-		elements.summary = document.getElementById("submission-summary");
-	}
-
-	function populateStaticSelects() {
-		(wubetBoot.exam_options || []).forEach(option => {
-			examScoreMap[option.value] = option.max_score;
-			addOption(elements.exam, option.value, option.label);
+		document.addEventListener("DOMContentLoaded", () => {
+			cacheElements();
+			populateStaticSelects();
+			registerListeners();
+			setDefaultValues();
 		});
 
-		addOption(elements.semester, "", __("Select Semester"));
-		(wubetBoot.semesters || []).forEach(option => {
-			addOption(elements.semester, option.value, option.label);
-		});
-
-		(wubetBoot.grades || []).forEach(grade => {
-			const label = grade.program_name || grade.name;
-			addOption(elements.grade, grade.name, label);
-		});
-
-		(wubetBoot.subjects || []).forEach(subject => {
-			const label = subject.course_name || subject.name;
-			addOption(elements.subject, subject.name, label);
-		});
-
-		(wubetBoot.student_groups || []).forEach(group => {
-			const label = group.student_group_name || group.name;
-			const option = addOption(elements.studentGroup, group.name, label);
-			option.dataset.program = group.program || "";
-		});
-	}
-
-	function registerListeners() {
-		elements.form.addEventListener("submit", evt => evt.preventDefault());
-		elements.studentGroup.addEventListener("change", handleStudentGroupChange);
-		elements.student.addEventListener("change", handleStudentChange);
-		elements.exam.addEventListener("change", handleExamChange);
-		elements.score.addEventListener("input", handleScoreInput);
-		elements.logButton.addEventListener("click", logScore);
-		elements.submitButton.addEventListener("click", submitLoggedScores);
-		elements.clearButton.addEventListener("click", resetForm);
-	}
-
-	function setDefaultValues() {
-		if (wubetBoot.default_academic_year) {
-			elements.academicYear.value = wubetBoot.default_academic_year;
-		}
-		if (wubetBoot.semesters && wubetBoot.semesters.length) {
-			elements.semester.value = wubetBoot.semesters[0].value;
-		}
-	}
-
-	function addOption(select, value, label) {
-		const option = document.createElement("option");
-		option.value = value;
-		option.textContent = label;
-		select.appendChild(option);
-		return option;
-	}
-
-	function handleStudentGroupChange(event) {
-		const selectedOption = event.target.selectedOptions[0];
-		const program = selectedOption ? selectedOption.dataset.program : "";
-		if (program) {
-			elements.grade.value = program;
-		}
-		loadStudentsForGroup(event.target.value);
-	}
-
-	function handleStudentChange(event) {
-		const selectedOption = event.target.selectedOptions[0];
-		elements.studentName.value = selectedOption ? selectedOption.dataset.studentName || "" : "";
-	}
-
-	function handleExamChange(event) {
-		const exam = event.target.value;
-		elements.maxScore.value = exam ? (examScoreMap[exam] || "") : "";
-		handleScoreInput();
-	}
-
-	function handleScoreInput() {
-		const max = parseFloat(elements.maxScore.value || "0");
-		const score = parseFloat(elements.score.value || "0");
-		if (max && score > max) {
-			elements.score.setCustomValidity("Score cannot exceed maximum score.");
-		} else {
-			elements.score.setCustomValidity("");
-		}
-	}
-
-	function resetForm() {
-		elements.form.reset();
-		setDefaultValues();
-		elements.student.innerHTML = `<option value="">${__("Select Student")}</option>`;
-		elements.student.disabled = true;
-		elements.studentName.value = "";
-		elements.maxScore.value = "";
-		clearFeedback();
-	}
-
-	function loadStudentsForGroup(studentGroup) {
-		elements.student.innerHTML = `<option value="">${__("Select Student")}</option>`;
-		elements.student.disabled = true;
-		elements.studentName.value = "";
-
-		if (!studentGroup) {
-			return;
+		function cacheElements() {
+			elements.form = document.getElementById("result-entry-form");
+			elements.feedback = document.getElementById("form-feedback");
+			elements.studentGroup = document.getElementById("student-group");
+			elements.student = document.getElementById("student");
+			elements.studentName = document.getElementById("student-name");
+			elements.grade = document.getElementById("grade");
+			elements.subject = document.getElementById("subject");
+			elements.academicYear = document.getElementById("academic-year");
+			elements.semester = document.getElementById("semester");
+			elements.exam = document.getElementById("exam");
+			elements.maxScore = document.getElementById("max-score");
+			elements.score = document.getElementById("score");
+			elements.logButton = document.getElementById("log-score-btn");
+			elements.submitButton = document.getElementById("submit-scores-btn");
+			elements.clearButton = document.getElementById("clear-form-btn");
+			elements.entriesBody = document.getElementById("logged-entries-body");
+			elements.noEntriesRow = document.getElementById("no-entries-row");
+			elements.studentLoading = document.getElementById("student-loading");
+			elements.summary = document.getElementById("submission-summary");
 		}
 
-		elements.studentLoading.style.display = "inline";
-		const request = frappe.call({
-			method: "education.education.api.get_students_for_group",
-			args: { student_group: studentGroup },
-			callback: response => {
-				const students = (response && response.message) || [];
-				students.forEach(student => {
-					const label = `${student.student} - ${student.student_name}`;
-					const option = addOption(elements.student, student.student, label);
-					option.dataset.studentName = student.student_name || "";
-				});
-				elements.student.disabled = students.length === 0;
-				if (students.length === 0) {
-					showFeedback(__("No students found for the selected group."), "warning");
-				} else {
-					clearFeedback();
-				}
-				elements.studentLoading.style.display = "none";
-			},
-			error: () => {
-				showFeedback(__("Unable to load students. Please try again."), "danger");
-				elements.studentLoading.style.display = "none";
+		function populateStaticSelects() {
+			addOption(elements.semester, "", TEXT.selectSemester);
+			(wubetBoot.semesters || []).forEach(option => {
+				addOption(elements.semester, option.value, option.label);
+			});
+
+			(wubetBoot.exam_options || []).forEach(option => {
+				examScoreMap[option.value] = option.max_score;
+				addOption(elements.exam, option.value, option.label);
+			});
+
+			(wubetBoot.grades || []).forEach(grade => {
+				const label = grade.program_name || grade.name;
+				addOption(elements.grade, grade.name, label);
+			});
+
+			(wubetBoot.subjects || []).forEach(subject => {
+				const label = subject.course_name || subject.name;
+				addOption(elements.subject, subject.name, label);
+			});
+
+			(wubetBoot.student_groups || []).forEach(group => {
+				const label = group.student_group_name || group.name;
+				const option = addOption(elements.studentGroup, group.name, label);
+				option.dataset.program = group.program || "";
+			});
+		}
+
+		function registerListeners() {
+			elements.form.addEventListener("submit", evt => evt.preventDefault());
+			elements.studentGroup.addEventListener("change", handleStudentGroupChange);
+			elements.student.addEventListener("change", handleStudentChange);
+			elements.exam.addEventListener("change", handleExamChange);
+			elements.score.addEventListener("input", handleScoreInput);
+			elements.logButton.addEventListener("click", logScore);
+			elements.submitButton.addEventListener("click", submitLoggedScores);
+			elements.clearButton.addEventListener("click", resetForm);
+		}
+
+		function setDefaultValues() {
+			if (wubetBoot.default_academic_year) {
+				elements.academicYear.value = wubetBoot.default_academic_year;
 			}
-		});
-	}
-
-	function validateEntry() {
-		const errors = [];
-		const entry = {
-			student_group: elements.studentGroup.value,
-			student: elements.student.value,
-			student_name: elements.studentName.value,
-			grade: elements.grade.value,
-			subject: elements.subject.value,
-			academic_year: elements.academicYear.value.trim(),
-			semester: elements.semester.value,
-			exam: elements.exam.value,
-			max_score: parseFloat(elements.maxScore.value || "0"),
-			score: parseFloat(elements.score.value || "0")
-		};
-
-		if (!entry.student_group) errors.push(__("Student Group is required."));
-		if (!entry.student) errors.push(__("Student is required."));
-		if (!entry.grade) errors.push(__("Grade / Program is required."));
-		if (!entry.subject) errors.push(__("Subject is required."));
-		if (!entry.academic_year) errors.push(__("Academic Year is required."));
-		if (!entry.semester) errors.push(__("Semester is required."));
-		if (!entry.exam) errors.push(__("Exam is required."));
-		if (!entry.max_score) errors.push(__("Maximum Score is required. Select an exam to set it automatically."));
-		if (!entry.score && entry.score !== 0) {
-			errors.push(__("Score is required."));
-		} else if (entry.max_score && entry.score > entry.max_score) {
-			errors.push(__("Score cannot exceed Maximum Score."));
+			if (wubetBoot.semesters && wubetBoot.semesters.length) {
+				elements.semester.value = wubetBoot.semesters[0].value;
+			}
 		}
 
-		if (errors.length) {
-			showFeedback(errors.join(" "), "danger");
-			return null;
+		function addOption(select, value, label) {
+			const option = document.createElement("option");
+			option.value = value;
+			option.textContent = label;
+			select.appendChild(option);
+			return option;
 		}
 
-		entry.section = entry.student_group;
-		return entry;
-	}
-
-	function logScore() {
-		const entry = validateEntry();
-		if (!entry) {
-			return;
+		function handleStudentGroupChange(event) {
+			const selectedOption = event.target.selectedOptions[0];
+			const program = selectedOption ? selectedOption.dataset.program : "";
+			if (program) {
+				elements.grade.value = program;
+			}
+			loadStudentsForGroup(event.target.value);
 		}
 
-		const displayEntry = {
-			...entry,
-			student_label: elements.student.selectedOptions[0]?.textContent || entry.student,
-			subject_label: elements.subject.selectedOptions[0]?.textContent || entry.subject,
-			grade_label: elements.grade.selectedOptions[0]?.textContent || entry.grade
-		};
-
-		state.loggedEntries.push(displayEntry);
-		renderEntries();
-		showFeedback(__("Score added to the queue. Remember to submit logged scores."), "success");
-		enableSubmit();
-		elements.score.value = "";
-	}
-
-	function renderEntries() {
-		elements.entriesBody.innerHTML = "";
-		if (!state.loggedEntries.length) {
-			elements.entriesBody.appendChild(elements.noEntriesRow);
-			elements.noEntriesRow.style.display = "table-row";
-			disableSubmit();
-			elements.summary.style.display = "none";
-			elements.summary.innerHTML = "";
-			return;
+		function handleStudentChange(event) {
+			const selectedOption = event.target.selectedOptions[0];
+			elements.studentName.value = selectedOption ? selectedOption.dataset.studentName || "" : "";
 		}
 
-		elements.noEntriesRow.style.display = "none";
-		state.loggedEntries.forEach((entry, index) => {
-			const row = document.createElement("tr");
-			row.innerHTML = `
-				<td>${entry.academic_year}</td>
-				<td>${entry.semester}</td>
-				<td>${entry.student_group}</td>
-				<td>${entry.student}</td>
-				<td>${entry.student_name || ""}</td>
-				<td>${entry.grade_label || entry.grade}</td>
-				<td>${entry.subject_label || entry.subject}</td>
-				<td>${entry.exam}</td>
-				<td class="text-right">${formatNumber(entry.score)}</td>
-				<td class="text-right">${formatNumber(entry.max_score)}</td>
-				<td class="text-center">
-					<button type="button" class="btn btn-xs btn-danger remove-entry-btn" data-index="${index}">
-						${__("Remove")}
-					</button>
-				</td>
-			`;
-			row.querySelector(".remove-entry-btn").addEventListener("click", () => removeEntry(index));
-			elements.entriesBody.appendChild(row);
-		});
-	}
+		function handleExamChange(event) {
+			const exam = event.target.value;
+			elements.maxScore.value = exam ? (examScoreMap[exam] || "") : "";
+			handleScoreInput();
+		}
 
-	function removeEntry(index) {
-		state.loggedEntries.splice(index, 1);
-		renderEntries();
-		if (state.loggedEntries.length) {
-			showFeedback(__("Entry removed."), "info");
-		} else {
+		function handleScoreInput() {
+			const max = parseFloat(elements.maxScore.value || "0");
+			const score = parseFloat(elements.score.value || "0");
+			if (max && score > max) {
+				elements.score.setCustomValidity(TEXT.scoreLimit);
+			} else {
+				elements.score.setCustomValidity("");
+			}
+		}
+
+		function resetForm() {
+			elements.form.reset();
+			setDefaultValues();
+			elements.student.innerHTML = `<option value="">${TEXT.selectStudent}</option>`;
+			elements.student.disabled = true;
+			elements.studentName.value = "";
+			elements.maxScore.value = "";
 			clearFeedback();
 		}
-	}
 
-	function enableSubmit() {
-		elements.submitButton.disabled = state.loggedEntries.length === 0;
-	}
+		function loadStudentsForGroup(studentGroup) {
+			elements.student.innerHTML = `<option value="">${TEXT.selectStudent}</option>`;
+			elements.student.disabled = true;
+			elements.studentName.value = "";
 
-	function disableSubmit() {
-		elements.submitButton.disabled = true;
-	}
-
-	function formatNumber(number) {
-		return (Number(number || 0)).toFixed(2);
-	}
-
-	async function submitLoggedScores() {
-		if (!state.loggedEntries.length) {
-			showFeedback(__("No scores to submit."), "warning");
-			return;
-		}
-
-		disableButtons(true);
-		showFeedback(__("Submitting scores..."), "info");
-
-		const summary = {
-			success: [],
-			failed: []
-		};
-
-		for (const entry of state.loggedEntries) {
-			try {
-				await callCreateResult(entry);
-				summary.success.push(entry);
-			} catch (error) {
-				summary.failed.push({ entry, error: parseError(error) });
+			if (!studentGroup) {
+				return;
 			}
-		}
 
-		disableButtons(false);
-		handleSubmissionSummary(summary);
-	}
-
-	function disableButtons(isDisabled) {
-		elements.logButton.disabled = isDisabled;
-		elements.submitButton.disabled = isDisabled;
-		elements.clearButton.disabled = isDisabled;
-	}
-
-	function callCreateResult(entry) {
-		return new Promise((resolve, reject) => {
+			elements.studentLoading.style.display = "block";
 			frappe.call({
-				method: "education.education.api.create_and_submit_term_subject_result",
-				args: { data: JSON.stringify(entry) },
+				method: "education.education.api.get_students_for_group",
+				args: { student_group: studentGroup },
 				callback: response => {
-					if (response && response.exc) {
-						reject(response.exc);
+					const students = (response && response.message) || [];
+					students.forEach(student => {
+						const label = `${student.student} - ${student.student_name}`;
+						const option = addOption(elements.student, student.student, label);
+						option.dataset.studentName = student.student_name || "";
+					});
+					elements.student.disabled = students.length === 0;
+					if (students.length === 0) {
+						showFeedback(TEXT.noStudents, "warning");
 					} else {
-						resolve(response.message);
+						clearFeedback();
 					}
+					elements.studentLoading.style.display = "none";
 				},
-				error: error => reject(error)
+				error: () => {
+					showFeedback(TEXT.loadStudentsError, "danger");
+					elements.studentLoading.style.display = "none";
+				}
 			});
-		});
-	}
+		}
 
-	function parseError(error) {
-		if (!error) return __("Unexpected error");
-		if (typeof error === "string") return error;
-		if (error._server_messages) {
-			try {
-				const messages = JSON.parse(error._server_messages);
-				return messages.map(msg => {
-					try {
-						return JSON.parse(msg).message || msg;
-					} catch (e) {
-						return msg;
-					}
-				}).join(" ");
-			} catch (e) {
-				return error._server_messages;
+		function validateEntry() {
+			const errors = [];
+			const entry = {
+				student_group: elements.studentGroup.value,
+				student: elements.student.value,
+				student_name: elements.studentName.value,
+				grade: elements.grade.value,
+				subject: elements.subject.value,
+				academic_year: elements.academicYear.value.trim(),
+				semester: elements.semester.value,
+				exam: elements.exam.value,
+				max_score: parseFloat(elements.maxScore.value || "0"),
+				score: parseFloat(elements.score.value || "0")
+			};
+
+			const requiredFields = [
+				{ value: entry.student_group, label: "{{ _('Student Group') | escapejs }}" },
+				{ value: entry.student, label: "{{ _('Student') | escapejs }}" },
+				{ value: entry.grade, label: "{{ _('Grade / Program') | escapejs }}" },
+				{ value: entry.subject, label: "{{ _('Subject') | escapejs }}" },
+				{ value: entry.academic_year, label: "{{ _('Academic Year') | escapejs }}" },
+				{ value: entry.semester, label: "{{ _('Semester') | escapejs }}" },
+				{ value: entry.exam, label: "{{ _('Exam') | escapejs }}" }
+			];
+
+			requiredFields.forEach(field => {
+				if (!field.value) {
+					errors.push(`${field.label} ${TEXT.fieldRequired}`);
+				}
+			});
+
+			if (!entry.max_score) {
+				errors.push(TEXT.maxScoreRequired);
+			}
+			if (entry.score === "" || entry.score === null || Number.isNaN(entry.score)) {
+				errors.push(TEXT.scoreRequired);
+			} else if (entry.max_score && entry.score > entry.max_score) {
+				errors.push(TEXT.scoreLimit);
+			}
+
+			if (errors.length) {
+				showFeedback(errors.join(" "), "danger");
+				return null;
+			}
+
+			entry.section = entry.student_group;
+			return entry;
+		}
+
+		function logScore() {
+			const entry = validateEntry();
+			if (!entry) return;
+
+			const displayEntry = {
+				...entry,
+				student_label: elements.student.selectedOptions[0]?.textContent || entry.student,
+				subject_label: elements.subject.selectedOptions[0]?.textContent || entry.subject,
+				grade_label: elements.grade.selectedOptions[0]?.textContent || entry.grade
+			};
+
+			state.loggedEntries.push(displayEntry);
+			renderEntries();
+			showFeedback(TEXT.entryQueued, "success");
+			enableSubmit();
+			elements.score.value = "";
+		}
+
+		function renderEntries() {
+			elements.entriesBody.innerHTML = "";
+			if (!state.loggedEntries.length) {
+				elements.entriesBody.appendChild(elements.noEntriesRow);
+				elements.noEntriesRow.style.display = "table-row";
+				disableSubmit();
+				elements.summary.style.display = "none";
+				elements.summary.innerHTML = "";
+				return;
+			}
+
+			elements.noEntriesRow.style.display = "none";
+			state.loggedEntries.forEach((entry, index) => {
+				const row = document.createElement("tr");
+				row.innerHTML = `
+					<td>${entry.academic_year}</td>
+					<td>${entry.semester}</td>
+					<td>${entry.student_group}</td>
+					<td>${entry.student}</td>
+					<td>${entry.student_name || ""}</td>
+					<td>${entry.grade_label || entry.grade}</td>
+					<td>${entry.subject_label || entry.subject}</td>
+					<td>${entry.exam}</td>
+					<td>${formatNumber(entry.score)}</td>
+					<td>${formatNumber(entry.max_score)}</td>
+					<td class="table-actions">
+						<button type="button" data-index="${index}">{{ _('Remove') }}</button>
+					</td>
+				`;
+				row.querySelector("button").addEventListener("click", () => removeEntry(index));
+				elements.entriesBody.appendChild(row);
+			});
+		}
+
+		function removeEntry(index) {
+			state.loggedEntries.splice(index, 1);
+			renderEntries();
+			if (state.loggedEntries.length) {
+				showFeedback(TEXT.entryRemoved, "info");
+			} else {
+				clearFeedback();
 			}
 		}
-		if (error.message) return error.message;
-		return __("Failed to submit entry");
-	}
 
-	function handleSubmissionSummary(summary) {
-		let summaryHtml = "";
-		if (summary.success.length) {
-			const count = summary.success.length;
-			summaryHtml += `<div class="alert alert-success">${__("Submitted {0} score(s) successfully.", [count])}</div>`;
-		}
-		if (summary.failed.length) {
-			const details = summary.failed.map(item => {
-				const student = item.entry.student_name || item.entry.student;
-				return `<li><strong>${escapeHtml(student)}</strong>: ${escapeHtml(item.error)}</li>`;
-			}).join("");
-			summaryHtml += `
-				<div class="alert alert-warning">
-					<p>${__("Some submissions failed:")}</p>
-					<ul>${details}</ul>
-				</div>`;
+		function enableSubmit() {
+			elements.submitButton.disabled = state.loggedEntries.length === 0;
 		}
 
-		elements.summary.innerHTML = summaryHtml;
-		elements.summary.style.display = summaryHtml ? "block" : "none";
-
-		if (summary.failed.length === 0) {
-			state.loggedEntries = [];
-			renderEntries();
-			showFeedback(__("All scores were submitted successfully."), "success");
-		} else if (summary.success.length) {
-			state.loggedEntries = summary.failed.map(item => item.entry);
-			renderEntries();
-			showFeedback(__("Some scores failed to submit. Please review the messages below."), "warning");
-		} else {
-			showFeedback(__("Unable to submit any of the queued scores."), "danger");
+		function disableSubmit() {
+			elements.submitButton.disabled = true;
 		}
-	}
 
-	function showFeedback(message, level) {
-		elements.feedback.className = `alert alert-${level}`;
-		elements.feedback.textContent = message;
-		elements.feedback.style.display = "block";
-	}
+		function formatNumber(number) {
+			return (Number(number || 0)).toFixed(2);
+		}
 
-	function clearFeedback() {
-		elements.feedback.style.display = "none";
-		elements.feedback.textContent = "";
-	}
+		async function submitLoggedScores() {
+			if (!state.loggedEntries.length) {
+				showFeedback(TEXT.noEntriesSubmit, "warning");
+				return;
+			}
 
-	function escapeHtml(value) {
-		const div = document.createElement("div");
-		div.textContent = value || "";
-		return div.innerHTML;
-	}
-</script>
-{% endblock %}
+			disableButtons(true);
+			showFeedback(TEXT.submitting, "info");
+
+			const summary = { success: [], failed: [] };
+
+			for (const entry of state.loggedEntries) {
+				try {
+					await callCreateResult(entry);
+					summary.success.push(entry);
+				} catch (error) {
+					summary.failed.push({ entry, error: parseError(error) });
+				}
+			}
+
+			disableButtons(false);
+			handleSubmissionSummary(summary);
+		}
+
+		function disableButtons(isDisabled) {
+			elements.logButton.disabled = isDisabled;
+			elements.submitButton.disabled = isDisabled;
+			elements.clearButton.disabled = isDisabled;
+		}
+
+		function callCreateResult(entry) {
+			return new Promise((resolve, reject) => {
+				frappe.call({
+					method: "education.education.api.create_and_submit_term_subject_result",
+					args: { data: JSON.stringify(entry) },
+					callback: response => {
+						if (response && response.exc) {
+							reject(response.exc);
+						} else {
+							resolve(response.message);
+						}
+					},
+					error: error => reject(error)
+				});
+			});
+		}
+
+		function parseError(error) {
+			if (!error) return "Unexpected error";
+			if (typeof error === "string") return error;
+			if (error._server_messages) {
+				try {
+					const messages = JSON.parse(error._server_messages);
+					return messages.map(msg => {
+						try {
+							return JSON.parse(msg).message || msg;
+						} catch (e) {
+							return msg;
+						}
+					}).join(" ");
+				} catch (e) {
+					return error._server_messages;
+				}
+			}
+			if (error.message) return error.message;
+			return "Failed to submit entry";
+		}
+
+		function handleSubmissionSummary(summary) {
+			let summaryHtml = "";
+			if (summary.success.length) {
+				const message = TEXT.submittedTemplate.replace("{0}", summary.success.length);
+				summaryHtml += `<div class="alert alert-success">${escapeHtml(message)}</div>`;
+			}
+			if (summary.failed.length) {
+				const details = summary.failed.map(item => {
+					const student = item.entry.student_name || item.entry.student;
+					return `<li><strong>${escapeHtml(student)}</strong>: ${escapeHtml(item.error)}</li>`;
+				}).join("");
+				summaryHtml += `
+					<div class="alert alert-warning">
+						<p>${escapeHtml(TEXT.someFailed)}</p>
+						<ul>${details}</ul>
+					</div>`;
+			}
+
+			elements.summary.innerHTML = summaryHtml;
+			elements.summary.style.display = summaryHtml ? "block" : "none";
+
+			if (summary.failed.length === 0) {
+				state.loggedEntries = [];
+				renderEntries();
+				showFeedback(TEXT.allSuccess, "success");
+			} else if (summary.success.length) {
+				state.loggedEntries = summary.failed.map(item => item.entry);
+				renderEntries();
+				showFeedback(TEXT.someFailedSummary, "warning");
+			} else {
+				showFeedback(TEXT.allFailed, "danger");
+			}
+		}
+
+		function showFeedback(message, level) {
+			elements.feedback.className = `alert alert-${level}`;
+			elements.feedback.textContent = message;
+			elements.feedback.style.display = "block";
+		}
+
+		function clearFeedback() {
+			elements.feedback.style.display = "none";
+			elements.feedback.textContent = "";
+		}
+
+		function escapeHtml(value) {
+			const div = document.createElement("div");
+			div.textContent = value || "";
+			return div.innerHTML;
+		}
+	</script>
+</body>
+</html>

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -187,6 +187,25 @@
 			font-size: 12px;
 			color: #6b7280;
 		}
+
+		input[readonly] {
+			background-color: #f8fafc;
+			color: #475569;
+		}
+
+		.score-input {
+			width: 120px;
+			padding: 8px 10px;
+			border: 1px solid #cfd8e3;
+			border-radius: 6px;
+			font-size: 14px;
+		}
+
+		.score-input:focus {
+			outline: none;
+			border-color: #2563eb;
+			box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+		}
 	</style>
 </head>
 <body>
@@ -215,23 +234,8 @@
 						<div id="student-loading" class="small-text" style="display: none;">{{ _("Loading students...") }}</div>
 					</div>
 					<div>
-						<label for="student">{{ _("Student") }}</label>
-						<select id="student" disabled required>
-							<option value="">{{ _("Select Student") }}</option>
-						</select>
-					</div>
-					<div>
-						<label for="student-name">{{ _("Student Name") }}</label>
-						<input type="text" id="student-name" placeholder="{{ _('Auto-filled after selecting a student') }}" readonly>
-					</div>
-				</div>
-
-				<div class="form-grid" style="margin-top: 20px;">
-					<div>
-						<label for="grade">{{ _("Grade / Program") }}</label>
-						<select id="grade" required>
-							<option value="">{{ _("Select Grade / Program") }}</option>
-						</select>
+						<label for="grade-display">{{ _("Grade / Program") }}</label>
+						<input type="text" id="grade-display" placeholder="{{ _('Auto-filled from Student Group') }}" readonly>
 					</div>
 					<div>
 						<label for="subject">{{ _("Subject") }}</label>
@@ -260,18 +264,35 @@
 						<label for="max-score">{{ _("Maximum Score") }}</label>
 						<input type="number" id="max-score" readonly>
 					</div>
-					<div>
-						<label for="score">{{ _("Score") }}</label>
-						<input type="number" id="score" min="0" step="0.01" required>
-					</div>
 				</div>
+
+				<p class="small-text" style="margin-top: 16px;">
+					{{ _("After selecting a student group, enter scores for each student in the list below. You can log multiple students at once.") }}
+				</p>
 
 				<div class="actions-row">
 					<button type="button" class="btn-secondary" id="clear-form-btn">{{ _("Reset Form") }}</button>
-					<button type="button" class="btn-primary" id="log-score-btn">{{ _("Log Score") }}</button>
+					<button type="button" class="btn-primary" id="log-score-btn">{{ _("Log Scores") }}</button>
 					<button type="button" class="btn-success" id="submit-scores-btn" disabled>{{ _("Submit Logged Scores") }}</button>
 				</div>
 			</form>
+		</section>
+
+		<section class="card">
+			<h3>{{ _("Students in Selected Group") }}</h3>
+			<p class="small-text" id="students-helper-text">{{ _("Select a Student Group to load students.") }}</p>
+			<div class="table-wrapper" id="students-table-wrapper" style="display: none;">
+				<table>
+					<thead>
+						<tr>
+							<th>{{ _("Student ID") }}</th>
+							<th>{{ _("Student Name") }}</th>
+							<th>{{ _("Score") }}</th>
+						</tr>
+					</thead>
+					<tbody id="students-table-body"></tbody>
+				</table>
+			</div>
 		</section>
 
 		<section class="card">
@@ -296,7 +317,7 @@
 					<tbody id="logged-entries-body">
 						<tr id="no-entries-row">
 							<td colspan="11" style="text-align: center; color: #94a3b8;">
-								{{ _("No scores queued yet. Log a score to get started.") }}
+								{{ _("No scores queued yet. Log scores to get started.") }}
 							</td>
 						</tr>
 					</tbody>
@@ -309,16 +330,16 @@
 	<script>
 		const TEXT = {
 			selectSemester: "Select Semester",
-			selectStudent: "Select Student",
 			noStudents: "No students found for the selected group.",
 			loadStudentsError: "Unable to load students. Please try again.",
 			fieldRequired: "is required.",
 			maxScoreRequired: "Maximum Score is required. Select an exam to set it automatically.",
-			scoreRequired: "Score is required.",
+			scoreRequired: "Score is required for logged students.",
 			scoreLimit: "Score cannot exceed Maximum Score.",
-			entryQueued: "Score added to the queue. Remember to submit logged scores.",
+			entryQueued: "Scores added to the queue. Remember to submit logged scores.",
 			entryRemoved: "Entry removed.",
 			noEntriesSubmit: "No scores to submit.",
+			noStudentScores: "Enter a score for at least one student before logging.",
 			submitting: "Submitting scores...",
 			submittedTemplate: "Submitted {0} score(s) successfully.",
 			someFailed: "Some submissions failed:",
@@ -327,31 +348,37 @@
 			allFailed: "Unable to submit any of the queued scores."
 		};
 
-		const state = { loggedEntries: [] };
+		const csrfToken = "{{ csrf_token | default('', true) }}";
 		const wubetBoot = {{ wubet_boot | safe }};
 		const elements = {};
 		const examScoreMap = {};
+		const programLabelMap = {};
+		const state = {
+			loggedEntries: [],
+			students: [],
+			studentScores: {},
+			currentGrade: { value: "", label: "" }
+		};
 
 		document.addEventListener("DOMContentLoaded", () => {
 			cacheElements();
+			buildProgramLabelMap();
 			populateStaticSelects();
 			registerListeners();
 			setDefaultValues();
+			renderStudentsTable();
 		});
 
 		function cacheElements() {
 			elements.form = document.getElementById("result-entry-form");
 			elements.feedback = document.getElementById("form-feedback");
 			elements.studentGroup = document.getElementById("student-group");
-			elements.student = document.getElementById("student");
-			elements.studentName = document.getElementById("student-name");
-			elements.grade = document.getElementById("grade");
+			elements.gradeDisplay = document.getElementById("grade-display");
 			elements.subject = document.getElementById("subject");
 			elements.academicYear = document.getElementById("academic-year");
 			elements.semester = document.getElementById("semester");
 			elements.exam = document.getElementById("exam");
 			elements.maxScore = document.getElementById("max-score");
-			elements.score = document.getElementById("score");
 			elements.logButton = document.getElementById("log-score-btn");
 			elements.submitButton = document.getElementById("submit-scores-btn");
 			elements.clearButton = document.getElementById("clear-form-btn");
@@ -359,6 +386,16 @@
 			elements.noEntriesRow = document.getElementById("no-entries-row");
 			elements.studentLoading = document.getElementById("student-loading");
 			elements.summary = document.getElementById("submission-summary");
+			elements.studentsHelperText = document.getElementById("students-helper-text");
+			elements.studentsTableWrapper = document.getElementById("students-table-wrapper");
+			elements.studentsTableBody = document.getElementById("students-table-body");
+		}
+
+		function buildProgramLabelMap() {
+			(wubetBoot.grades || []).forEach(grade => {
+				const label = grade.program_name || grade.name;
+				programLabelMap[grade.name] = label;
+			});
 		}
 
 		function populateStaticSelects() {
@@ -370,11 +407,6 @@
 			(wubetBoot.exam_options || []).forEach(option => {
 				examScoreMap[option.value] = option.max_score;
 				addOption(elements.exam, option.value, option.label);
-			});
-
-			(wubetBoot.grades || []).forEach(grade => {
-				const label = grade.program_name || grade.name;
-				addOption(elements.grade, grade.name, label);
 			});
 
 			(wubetBoot.subjects || []).forEach(subject => {
@@ -392,10 +424,8 @@
 		function registerListeners() {
 			elements.form.addEventListener("submit", evt => evt.preventDefault());
 			elements.studentGroup.addEventListener("change", handleStudentGroupChange);
-			elements.student.addEventListener("change", handleStudentChange);
 			elements.exam.addEventListener("change", handleExamChange);
-			elements.score.addEventListener("input", handleScoreInput);
-			elements.logButton.addEventListener("click", logScore);
+			elements.logButton.addEventListener("click", logScores);
 			elements.submitButton.addEventListener("click", submitLoggedScores);
 			elements.clearButton.addEventListener("click", resetForm);
 		}
@@ -406,6 +436,11 @@
 			}
 			if (wubetBoot.semesters && wubetBoot.semesters.length) {
 				elements.semester.value = wubetBoot.semesters[0].value;
+			}
+			if (wubetBoot.exam_options && wubetBoot.exam_options.length) {
+				const firstExam = wubetBoot.exam_options[0].value;
+				elements.exam.value = firstExam;
+				elements.maxScore.value = examScoreMap[firstExam] || "";
 			}
 		}
 
@@ -419,117 +454,191 @@
 
 		function handleStudentGroupChange(event) {
 			const selectedOption = event.target.selectedOptions[0];
-			const program = selectedOption ? selectedOption.dataset.program : "";
-			if (program) {
-				elements.grade.value = program;
-			}
+			const programId = selectedOption ? selectedOption.dataset.program : "";
+			const label = programLabelMap[programId] || programId || "";
+			state.currentGrade = {
+				value: programId || "",
+				label: label || ""
+			};
+			elements.gradeDisplay.value = label || "";
 			loadStudentsForGroup(event.target.value);
-		}
-
-		function handleStudentChange(event) {
-			const selectedOption = event.target.selectedOptions[0];
-			elements.studentName.value = selectedOption ? selectedOption.dataset.studentName || "" : "";
 		}
 
 		function handleExamChange(event) {
 			const exam = event.target.value;
 			elements.maxScore.value = exam ? (examScoreMap[exam] || "") : "";
-			handleScoreInput();
-		}
-
-		function handleScoreInput() {
-			const max = parseFloat(elements.maxScore.value || "0");
-			const score = parseFloat(elements.score.value || "0");
-			if (max && score > max) {
-				elements.score.setCustomValidity(TEXT.scoreLimit);
-			} else {
-				elements.score.setCustomValidity("");
-			}
+			updateAllScoreInputsMax();
 		}
 
 		function resetForm() {
 			elements.form.reset();
+			elements.gradeDisplay.value = "";
+			state.currentGrade = { value: "", label: "" };
+			state.students = [];
+			state.studentScores = {};
 			setDefaultValues();
-			elements.student.innerHTML = `<option value="">${TEXT.selectStudent}</option>`;
-			elements.student.disabled = true;
-			elements.studentName.value = "";
-			elements.maxScore.value = "";
+			renderStudentsTable();
 			clearFeedback();
 		}
 
-		function loadStudentsForGroup(studentGroup) {
-			elements.student.innerHTML = `<option value="">${TEXT.selectStudent}</option>`;
-			elements.student.disabled = true;
-			elements.studentName.value = "";
+		async function loadStudentsForGroup(studentGroup) {
+			state.students = [];
+			state.studentScores = {};
+			renderStudentsTable();
 
 			if (!studentGroup) {
 				return;
 			}
 
 			elements.studentLoading.style.display = "block";
-			frappe.call({
-				method: "education.education.api.get_students_for_group",
-				args: { student_group: studentGroup },
-				callback: response => {
-					const students = (response && response.message) || [];
-					students.forEach(student => {
-						const label = `${student.student} - ${student.student_name}`;
-						const option = addOption(elements.student, student.student, label);
-						option.dataset.studentName = student.student_name || "";
-					});
-					elements.student.disabled = students.length === 0;
-					if (students.length === 0) {
-						showFeedback(TEXT.noStudents, "warning");
-					} else {
-						clearFeedback();
+
+			try {
+				const students = await apiCall(
+					"/api/method/education.education.api.get_students_for_group",
+					{ student_group: studentGroup }
+				);
+				state.students = students || [];
+				state.studentScores = {};
+				renderStudentsTable();
+				if (!state.students.length) {
+					showFeedback(TEXT.noStudents, "warning");
+				} else {
+					clearFeedback();
+				}
+			} catch (error) {
+				console.error(error);
+				showFeedback(TEXT.loadStudentsError, "danger");
+			} finally {
+				elements.studentLoading.style.display = "none";
+			}
+		}
+
+		function renderStudentsTable() {
+			if (!state.students.length) {
+				elements.studentsTableWrapper.style.display = "none";
+				elements.studentsHelperText.style.display = "block";
+				elements.studentsTableBody.innerHTML = "";
+				return;
+			}
+
+			elements.studentsHelperText.style.display = "none";
+			elements.studentsTableWrapper.style.display = "block";
+
+			const rows = state.students
+				.map(student => {
+					const studentIdRaw = student.student || "";
+					const studentNameRaw = student.student_name || "";
+					const studentId = escapeHtml(studentIdRaw);
+					const studentName = escapeHtml(studentNameRaw);
+					return `
+						<tr>
+							<td>${studentId}</td>
+							<td>${studentName}</td>
+							<td>
+								<input
+									type="number"
+									class="score-input"
+									data-student="${studentIdRaw}"
+									data-student-name="${studentNameRaw}"
+									min="0"
+									step="0.01"
+								/>
+							</td>
+						</tr>
+					`;
+				})
+				.join("");
+
+			elements.studentsTableBody.innerHTML = rows;
+			updateAllScoreInputsMax();
+			elements.studentsTableBody.querySelectorAll(".score-input").forEach(input => {
+				input.addEventListener("input", handleStudentScoreInput);
+			});
+		}
+
+		function handleStudentScoreInput(event) {
+			const input = event.target;
+			const studentId = input.dataset.student;
+			const studentName = input.dataset.studentName || "";
+			const value = input.value;
+
+			if (value === "") {
+				delete state.studentScores[studentId];
+				return;
+			}
+
+			let numeric = parseFloat(value);
+			if (Number.isNaN(numeric) || numeric < 0) {
+				input.value = "";
+				delete state.studentScores[studentId];
+				return;
+			}
+
+			const max = parseFloat(elements.maxScore.value || "0");
+			if (max && numeric > max) {
+				numeric = max;
+				input.value = max;
+			}
+
+			state.studentScores[studentId] = {
+				student: studentId,
+				student_name: studentName,
+				score: numeric
+			};
+		}
+
+		function updateAllScoreInputsMax() {
+			const max = parseFloat(elements.maxScore.value || "0");
+			elements.studentsTableBody.querySelectorAll(".score-input").forEach(input => {
+				if (max) {
+					input.setAttribute("max", max);
+					if (parseFloat(input.value || "0") > max) {
+						input.value = max;
+						const studentId = input.dataset.student;
+						if (state.studentScores[studentId]) {
+							state.studentScores[studentId].score = max;
+						}
 					}
-					elements.studentLoading.style.display = "none";
-				},
-				error: () => {
-					showFeedback(TEXT.loadStudentsError, "danger");
-					elements.studentLoading.style.display = "none";
+				} else {
+					input.removeAttribute("max");
 				}
 			});
 		}
 
-		function validateEntry() {
-			const errors = [];
-			const entry = {
+		function getCommonEntryData() {
+			const data = {
 				student_group: elements.studentGroup.value,
-				student: elements.student.value,
-				student_name: elements.studentName.value,
-				grade: elements.grade.value,
+				student_group_label: elements.studentGroup.selectedOptions[0]?.textContent || "",
+				grade: state.currentGrade.value,
+				grade_label: state.currentGrade.label || "",
 				subject: elements.subject.value,
+				subject_label: elements.subject.selectedOptions[0]?.textContent || "",
 				academic_year: elements.academicYear.value.trim(),
 				semester: elements.semester.value,
+				semester_label: elements.semester.selectedOptions[elements.semester.selectedIndex]?.textContent || "",
 				exam: elements.exam.value,
-				max_score: parseFloat(elements.maxScore.value || "0"),
-				score: parseFloat(elements.score.value || "0")
+				exam_label: elements.exam.selectedOptions[0]?.textContent || "",
+				max_score: parseFloat(elements.maxScore.value || "0")
 			};
 
-			const requiredFields = [
-				{ value: entry.student_group, label: "Student Group" },
-				{ value: entry.student, label: "Student" },
-				{ value: entry.grade, label: "Grade / Program" },
-				{ value: entry.subject, label: "Subject" },
-				{ value: entry.academic_year, label: "Academic Year" },
-				{ value: entry.semester, label: "Semester" },
-				{ value: entry.exam, label: "Exam" }
+			const required = [
+				{ value: data.student_group, label: "Student Group" },
+				{ value: data.grade, label: "Grade / Program" },
+				{ value: data.subject, label: "Subject" },
+				{ value: data.academic_year, label: "Academic Year" },
+				{ value: data.semester, label: "Semester" },
+				{ value: data.exam, label: "Exam" }
 			];
 
-			requiredFields.forEach(field => {
+			const errors = [];
+			required.forEach(field => {
 				if (!field.value) {
 					errors.push(`${field.label} ${TEXT.fieldRequired}`);
 				}
 			});
 
-			if (!entry.max_score) {
+			if (!data.max_score) {
 				errors.push(TEXT.maxScoreRequired);
-			}
-			if (entry.score === "" || entry.score === null || Number.isNaN(entry.score)) {
-				errors.push(TEXT.scoreRequired);
-			} else if (entry.max_score && entry.score > entry.max_score) {
-				errors.push(TEXT.scoreLimit);
 			}
 
 			if (errors.length) {
@@ -537,26 +646,45 @@
 				return null;
 			}
 
-			entry.section = entry.student_group;
-			return entry;
+			data.section = data.student_group;
+			return data;
 		}
 
-		function logScore() {
-			const entry = validateEntry();
-			if (!entry) return;
+		function getActiveScoreEntries() {
+			return Object.values(state.studentScores || {}).filter(item => typeof item.score === "number");
+		}
 
-			const displayEntry = {
-				...entry,
-				student_label: elements.student.selectedOptions[0]?.textContent || entry.student,
-				subject_label: elements.subject.selectedOptions[0]?.textContent || entry.subject,
-				grade_label: elements.grade.selectedOptions[0]?.textContent || entry.grade
-			};
+		function logScores() {
+			const common = getCommonEntryData();
+			if (!common) return;
 
-			state.loggedEntries.push(displayEntry);
+			const activeScores = getActiveScoreEntries();
+			if (!activeScores.length) {
+				showFeedback(TEXT.noStudentScores, "warning");
+				return;
+			}
+
+			activeScores.forEach(item => {
+				const entry = {
+					...common,
+					student: item.student,
+					student_name: item.student_name,
+					score: item.score
+				};
+				state.loggedEntries.push(entry);
+			});
+
+			clearStudentScoreInputs();
 			renderEntries();
 			showFeedback(TEXT.entryQueued, "success");
 			enableSubmit();
-			elements.score.value = "";
+		}
+
+		function clearStudentScoreInputs() {
+			state.studentScores = {};
+			elements.studentsTableBody.querySelectorAll(".score-input").forEach(input => {
+				input.value = "";
+			});
 		}
 
 		function renderEntries() {
@@ -574,14 +702,14 @@
 			state.loggedEntries.forEach((entry, index) => {
 				const row = document.createElement("tr");
 				row.innerHTML = `
-					<td>${entry.academic_year}</td>
-					<td>${entry.semester}</td>
-					<td>${entry.student_group}</td>
-					<td>${entry.student}</td>
-					<td>${entry.student_name || ""}</td>
-					<td>${entry.grade_label || entry.grade}</td>
-					<td>${entry.subject_label || entry.subject}</td>
-					<td>${entry.exam}</td>
+					<td>${escapeHtml(entry.academic_year)}</td>
+					<td>${escapeHtml(entry.semester_label || entry.semester)}</td>
+					<td>${escapeHtml(entry.student_group_label || entry.student_group)}</td>
+					<td>${escapeHtml(entry.student)}</td>
+					<td>${escapeHtml(entry.student_name || "")}</td>
+					<td>${escapeHtml(entry.grade_label || entry.grade)}</td>
+					<td>${escapeHtml(entry.subject_label || entry.subject)}</td>
+					<td>${escapeHtml(entry.exam_label || entry.exam)}</td>
 					<td>${formatNumber(entry.score)}</td>
 					<td>${formatNumber(entry.max_score)}</td>
 					<td class="table-actions">
@@ -631,7 +759,7 @@
 					await callCreateResult(entry);
 					summary.success.push(entry);
 				} catch (error) {
-					summary.failed.push({ entry, error: parseError(error) });
+					summary.failed.push({ entry, error: error.message || error });
 				}
 			}
 
@@ -645,42 +773,11 @@
 			elements.clearButton.disabled = isDisabled;
 		}
 
-		function callCreateResult(entry) {
-			return new Promise((resolve, reject) => {
-				frappe.call({
-					method: "education.education.api.create_and_submit_term_subject_result",
-					args: { data: JSON.stringify(entry) },
-					callback: response => {
-						if (response && response.exc) {
-							reject(response.exc);
-						} else {
-							resolve(response.message);
-						}
-					},
-					error: error => reject(error)
-				});
-			});
-		}
-
-		function parseError(error) {
-			if (!error) return "Unexpected error";
-			if (typeof error === "string") return error;
-			if (error._server_messages) {
-				try {
-					const messages = JSON.parse(error._server_messages);
-					return messages.map(msg => {
-						try {
-							return JSON.parse(msg).message || msg;
-						} catch (e) {
-							return msg;
-						}
-					}).join(" ");
-				} catch (e) {
-					return error._server_messages;
-				}
-			}
-			if (error.message) return error.message;
-			return "Failed to submit entry";
+		async function callCreateResult(entry) {
+			return apiCall(
+				"/api/method/education.education.api.create_and_submit_term_subject_result",
+				{ data: JSON.stringify(entry) }
+			);
 		}
 
 		function handleSubmissionSummary(summary) {
@@ -715,6 +812,41 @@
 			} else {
 				showFeedback(TEXT.allFailed, "danger");
 			}
+		}
+
+		async function apiCall(endpoint, payload) {
+			const headers = {
+				"Content-Type": "application/json",
+				"Accept": "application/json",
+				"X-Requested-With": "XMLHttpRequest"
+			};
+			if (csrfToken) {
+				headers["X-Frappe-CSRF-Token"] = csrfToken;
+			}
+
+			const response = await fetch(endpoint, {
+				method: "POST",
+				headers,
+				credentials: "include",
+				body: JSON.stringify(payload || {})
+			});
+
+			const data = await response.json().catch(() => ({}));
+
+			if (!response.ok || data.exc) {
+				const errorMessage = extractErrorMessage(data) || `${response.status} ${response.statusText}`;
+				throw new Error(errorMessage);
+			}
+
+			return data.message;
+		}
+
+		function extractErrorMessage(errorData) {
+			if (!errorData) return "";
+			if (errorData.message) return errorData.message;
+			if (errorData.exception) return errorData.exception;
+			if (errorData.exc) return Array.isArray(errorData.exc) ? errorData.exc.join(" ") : errorData.exc;
+			return "";
 		}
 
 		function showFeedback(message, level) {

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -473,7 +473,7 @@
 			if (!elements.studentsTableBody) return;
 			elements.studentsTableBody.querySelectorAll(".score-input").forEach(input => {
 				const stored = state.studentScores[input.dataset.student];
-				if (stored && typeof stored.score === "number") {
+				if (stored && typeof stored.score === "number" && !Number.isNaN(stored.score)) {
 					input.value = stored.score;
 				} else {
 					input.value = "";
@@ -484,27 +484,41 @@
 		async function fetchExistingScores() {
 			if (!hasScoreContext()) return;
 			const params = getScoreContextParams();
+			const filters = [
+				["Student Term Subject Result", "student_group", "=", params.student_group],
+				["Student Term Subject Result", "academic_year", "=", params.academic_year],
+				["Student Term Subject Result", "semester", "=", params.semester],
+				["Student Term Subject Result", "subject", "=", params.subject],
+				["Student Term Subject Result", "exam", "=", params.exam],
+				["Student Term Subject Result", "docstatus", "=", 0]
+			];
 			try {
 				const records = await apiCall(
-					"/api/method/education.education.api.get_student_group_scores",
-					params,
+					"/api/resource/Student Term Subject Result",
+					{
+						filters: JSON.stringify(filters),
+						fields: JSON.stringify(["name", "student", "student_name", "score", "max_score"])
+					},
 					{ method: "GET" }
 				);
 				state.studentScores = {};
 				state.resultDocs = {};
 				state.lastQueuedScores = {};
 				(records || []).forEach(record => {
-					const scoreValue = parseFloat(record.score);
+					const rawScore = record.score;
+					const scoreValue = rawScore === null || rawScore === undefined ? null : parseFloat(rawScore);
 					const studentId = record.student;
+					const key = buildScoreKey(studentId, params.subject, params.exam, params.academic_year, params.semester);
 					state.studentScores[studentId] = {
 						student: studentId,
 						student_name: record.student_name || "",
-						score: scoreValue,
+						score: Number.isNaN(scoreValue) ? null : scoreValue,
 						docname: record.name
 					};
-					const key = buildScoreKey(studentId, params.subject, params.exam, params.academic_year, params.semester);
 					state.resultDocs[key] = record.name;
-					state.lastQueuedScores[key] = scoreValue;
+					if (!Number.isNaN(scoreValue) && scoreValue !== null) {
+						state.lastQueuedScores[key] = scoreValue;
+					}
 				});
 				applyScoresToInputs();
 			} catch (error) {
@@ -919,14 +933,35 @@
 
 		async function callCreateResult(entry) {
 			const payload = {
-				...entry,
-				submit: 0,
-				naming_series: "STSR-.YYYY.-"
+				naming_series: "STSR-.YYYY.-",
+				student: entry.student,
+				student_name: entry.student_name,
+				academic_year: entry.academic_year,
+				semester: entry.semester,
+				subject: entry.subject,
+				student_group: entry.student_group,
+				grade: entry.grade,
+				exam: entry.exam,
+				score: entry.score,
+				max_score: entry.max_score,
+				examiner: entry.examiner || ""
 			};
-			const response = await apiCall(
-				"/api/method/education.education.api.create_student_term_subject_result",
-				{ result_data: payload }
-			);
+
+			let response;
+			if (entry.name) {
+				response = await apiCall(
+					`/api/resource/Student Term Subject Result/${encodeURIComponent(entry.name)}`,
+					payload,
+					{ method: "PUT" }
+				);
+			} else {
+				response = await apiCall(
+					"/api/resource/Student Term Subject Result",
+					{ doctype: "Student Term Subject Result", ...payload },
+					{ method: "POST" }
+				);
+			}
+
 			const docName = response && response.name;
 			if (docName) {
 				const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
@@ -1017,7 +1052,15 @@
 				throw new Error(errorMessage);
 			}
 
-			return data.message;
+			if (Object.prototype.hasOwnProperty.call(data, "message")) {
+				return data.message;
+			}
+
+			if (Object.prototype.hasOwnProperty.call(data, "data")) {
+				return data.data;
+			}
+
+			return data;
 		}
 
 		function extractErrorMessage(errorData) {
@@ -1051,8 +1094,10 @@
 			const ctx = getScoreContextParams();
 			state.lastQueuedScores = {};
 			Object.values(state.studentScores || {}).forEach(item => {
-				const key = buildScoreKey(item.student, ctx.subject, ctx.exam, ctx.academic_year, ctx.semester);
-				state.lastQueuedScores[key] = item.score;
+				if (typeof item.score === "number" && !Number.isNaN(item.score)) {
+					const key = buildScoreKey(item.student, ctx.subject, ctx.exam, ctx.academic_year, ctx.semester);
+					state.lastQueuedScores[key] = item.score;
+				}
 			});
 		}
 

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -308,23 +308,23 @@
 
 	<script>
 		const TEXT = {
-			selectSemester: "{{ _('Select Semester') | escapejs }}",
-			selectStudent: "{{ _('Select Student') | escapejs }}",
-			noStudents: "{{ _('No students found for the selected group.') | escapejs }}",
-			loadStudentsError: "{{ _('Unable to load students. Please try again.') | escapejs }}",
-			fieldRequired: "{{ _('is required.') | escapejs }}",
-			maxScoreRequired: "{{ _('Maximum Score is required. Select an exam to set it automatically.') | escapejs }}",
-			scoreRequired: "{{ _('Score is required.') | escapejs }}",
-			scoreLimit: "{{ _('Score cannot exceed Maximum Score.') | escapejs }}",
-			entryQueued: "{{ _('Score added to the queue. Remember to submit logged scores.') | escapejs }}",
-			entryRemoved: "{{ _('Entry removed.') | escapejs }}",
-			noEntriesSubmit: "{{ _('No scores to submit.') | escapejs }}",
-			submitting: "{{ _('Submitting scores...') | escapejs }}",
-			submittedTemplate: "{{ _('Submitted {0} score(s) successfully.') | escapejs }}",
-			someFailed: "{{ _('Some submissions failed:') | escapejs }}",
-			allSuccess: "{{ _('All scores were submitted successfully.') | escapejs }}",
-			someFailedSummary: "{{ _('Some scores failed to submit. Please review the messages below.') | escapejs }}",
-			allFailed: "{{ _('Unable to submit any of the queued scores.') | escapejs }}"
+			selectSemester: "Select Semester",
+			selectStudent: "Select Student",
+			noStudents: "No students found for the selected group.",
+			loadStudentsError: "Unable to load students. Please try again.",
+			fieldRequired: "is required.",
+			maxScoreRequired: "Maximum Score is required. Select an exam to set it automatically.",
+			scoreRequired: "Score is required.",
+			scoreLimit: "Score cannot exceed Maximum Score.",
+			entryQueued: "Score added to the queue. Remember to submit logged scores.",
+			entryRemoved: "Entry removed.",
+			noEntriesSubmit: "No scores to submit.",
+			submitting: "Submitting scores...",
+			submittedTemplate: "Submitted {0} score(s) successfully.",
+			someFailed: "Some submissions failed:",
+			allSuccess: "All scores were submitted successfully.",
+			someFailedSummary: "Some scores failed to submit. Please review the messages below.",
+			allFailed: "Unable to submit any of the queued scores."
 		};
 
 		const state = { loggedEntries: [] };
@@ -508,13 +508,13 @@
 			};
 
 			const requiredFields = [
-				{ value: entry.student_group, label: "{{ _('Student Group') | escapejs }}" },
-				{ value: entry.student, label: "{{ _('Student') | escapejs }}" },
-				{ value: entry.grade, label: "{{ _('Grade / Program') | escapejs }}" },
-				{ value: entry.subject, label: "{{ _('Subject') | escapejs }}" },
-				{ value: entry.academic_year, label: "{{ _('Academic Year') | escapejs }}" },
-				{ value: entry.semester, label: "{{ _('Semester') | escapejs }}" },
-				{ value: entry.exam, label: "{{ _('Exam') | escapejs }}" }
+				{ value: entry.student_group, label: "Student Group" },
+				{ value: entry.student, label: "Student" },
+				{ value: entry.grade, label: "Grade / Program" },
+				{ value: entry.subject, label: "Subject" },
+				{ value: entry.academic_year, label: "Academic Year" },
+				{ value: entry.semester, label: "Semester" },
+				{ value: entry.exam, label: "Exam" }
 			];
 
 			requiredFields.forEach(field => {

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -495,7 +495,8 @@
 			try {
 				const students = await apiCall(
 					"/api/method/education.education.api.get_students_for_group",
-					{ student_group: studentGroup }
+					{ student_group: studentGroup },
+					{ method: "GET" }
 				);
 				state.students = students || [];
 				state.studentScores = {};
@@ -814,21 +815,37 @@
 			}
 		}
 
-		async function apiCall(endpoint, payload) {
+		async function apiCall(endpoint, payload, options) {
+			const method = (options && options.method) || "POST";
+			let url = endpoint;
+			let body;
+
+			if (method === "GET") {
+				const params = new URLSearchParams(payload || {}).toString();
+				if (params) {
+					url += (url.includes("?") ? "&" : "?") + params;
+				}
+			} else {
+				body = JSON.stringify(payload || {});
+			}
+
 			const headers = {
-				"Content-Type": "application/json",
 				"Accept": "application/json",
 				"X-Requested-With": "XMLHttpRequest"
 			};
-			if (csrfToken) {
-				headers["X-Frappe-CSRF-Token"] = csrfToken;
+
+			if (method !== "GET") {
+				headers["Content-Type"] = "application/json";
+				if (csrfToken) {
+					headers["X-Frappe-CSRF-Token"] = csrfToken;
+				}
 			}
 
-			const response = await fetch(endpoint, {
-				method: "POST",
+			const response = await fetch(url, {
+				method,
 				headers,
 				credentials: "include",
-				body: JSON.stringify(payload || {})
+				body
 			});
 
 			const data = await response.json().catch(() => ({}));

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -337,6 +337,7 @@
 			scoreRequired: "Score is required for logged students.",
 			scoreLimit: "Score cannot exceed Maximum Score.",
 			entryQueued: "Scores added to the queue. Remember to submit logged scores.",
+			noNewScores: "No new or updated scores to log.",
 			entryRemoved: "Entry removed.",
 			noEntriesSubmit: "No scores to submit.",
 			noStudentScores: "Enter a score for at least one student before logging.",
@@ -357,6 +358,7 @@
 			loggedEntries: [],
 			students: [],
 			studentScores: {},
+			lastQueuedScores: {},
 			currentGrade: { value: "", label: "" }
 		};
 
@@ -461,6 +463,13 @@
 				label: label || ""
 			};
 			elements.gradeDisplay.value = label || "";
+			if (state.loggedEntries.length) {
+				state.loggedEntries = [];
+				state.lastQueuedScores = {};
+				renderEntries();
+				elements.summary.style.display = "none";
+				elements.summary.innerHTML = "";
+			}
 			loadStudentsForGroup(event.target.value);
 		}
 
@@ -476,9 +485,14 @@
 			state.currentGrade = { value: "", label: "" };
 			state.students = [];
 			state.studentScores = {};
+			state.lastQueuedScores = {};
+			state.loggedEntries = [];
 			setDefaultValues();
 			renderStudentsTable();
+			renderEntries();
 			clearFeedback();
+			elements.summary.style.display = "none";
+			elements.summary.innerHTML = "";
 		}
 
 		async function loadStudentsForGroup(studentGroup) {
@@ -655,6 +669,10 @@
 			return Object.values(state.studentScores || {}).filter(item => typeof item.score === "number");
 		}
 
+		function buildScoreKey(student, subject, exam, academicYear, semester) {
+			return [student || "", subject || "", exam || "", academicYear || "", semester || ""].join("::");
+		}
+
 		function logScores() {
 			const common = getCommonEntryData();
 			if (!common) return;
@@ -665,7 +683,15 @@
 				return;
 			}
 
+			const newEntries = [];
+
 			activeScores.forEach(item => {
+				const key = buildScoreKey(item.student, common.subject, common.exam, common.academic_year, common.semester);
+				const lastScore = state.lastQueuedScores[key];
+				if (lastScore !== undefined && lastScore === item.score) {
+					return;
+				}
+
 				const entry = {
 					...common,
 					student: item.student,
@@ -673,19 +699,18 @@
 					score: item.score
 				};
 				state.loggedEntries.push(entry);
+				state.lastQueuedScores[key] = item.score;
+				newEntries.push(entry);
 			});
 
-			clearStudentScoreInputs();
+			if (!newEntries.length) {
+				showFeedback(TEXT.noNewScores, "info");
+				return;
+			}
+
 			renderEntries();
 			showFeedback(TEXT.entryQueued, "success");
 			enableSubmit();
-		}
-
-		function clearStudentScoreInputs() {
-			state.studentScores = {};
-			elements.studentsTableBody.querySelectorAll(".score-input").forEach(input => {
-				input.value = "";
-			});
 		}
 
 		function renderEntries() {
@@ -723,12 +748,23 @@
 		}
 
 		function removeEntry(index) {
+			const entry = state.loggedEntries[index];
 			state.loggedEntries.splice(index, 1);
+			cleanupQueuedScore(entry);
 			renderEntries();
 			if (state.loggedEntries.length) {
 				showFeedback(TEXT.entryRemoved, "info");
 			} else {
 				clearFeedback();
+			}
+		}
+
+		function cleanupQueuedScore(entry) {
+			if (!entry) return;
+			const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
+			const stillQueued = state.loggedEntries.some(e => buildScoreKey(e.student, e.subject, e.exam, e.academic_year, e.semester) === key && e.student === entry.student);
+			if (!stillQueued) {
+				delete state.lastQueuedScores[key];
 			}
 		}
 
@@ -804,10 +840,12 @@
 
 			if (summary.failed.length === 0) {
 				state.loggedEntries = [];
+				state.lastQueuedScores = {};
 				renderEntries();
 				showFeedback(TEXT.allSuccess, "success");
 			} else if (summary.success.length) {
 				state.loggedEntries = summary.failed.map(item => item.entry);
+				rebuildQueuedScoreMap();
 				renderEntries();
 				showFeedback(TEXT.someFailedSummary, "warning");
 			} else {
@@ -875,6 +913,14 @@
 		function clearFeedback() {
 			elements.feedback.style.display = "none";
 			elements.feedback.textContent = "";
+		}
+
+		function rebuildQueuedScoreMap() {
+			state.lastQueuedScores = {};
+			state.loggedEntries.forEach(entry => {
+				const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
+				state.lastQueuedScores[key] = entry.score;
+			});
 		}
 
 		function escapeHtml(value) {

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -698,7 +698,7 @@
 					student_name: item.student_name,
 					score: item.score
 				};
-				state.loggedEntries.push(entry);
+				upsertLoggedEntry(entry, key);
 				state.lastQueuedScores[key] = item.score;
 				newEntries.push(entry);
 			});
@@ -759,6 +759,21 @@
 			}
 		}
 
+		function upsertLoggedEntry(entry, key) {
+			const index = state.loggedEntries.findIndex(existing => {
+				return (
+					existing.student === entry.student &&
+					buildScoreKey(existing.student, existing.subject, existing.exam, existing.academic_year, existing.semester) === key
+				);
+			});
+
+			if (index > -1) {
+				state.loggedEntries[index] = entry;
+			} else {
+				state.loggedEntries.push(entry);
+			}
+		}
+
 		function cleanupQueuedScore(entry) {
 			if (!entry) return;
 			const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
@@ -811,9 +826,13 @@
 		}
 
 		async function callCreateResult(entry) {
+			const payload = {
+				...entry,
+				submit: 1
+			};
 			return apiCall(
-				"/api/method/education.education.api.create_and_submit_term_subject_result",
-				{ data: JSON.stringify(entry) }
+				"/api/method/education.education.api.create_student_term_subject_result",
+				{ result_data: payload }
 			);
 		}
 

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -1,0 +1,576 @@
+{% extends "templates/web.html" %}
+
+{% block title %}{{ _("Student Result Entry") }}{% endblock %}
+
+{% block page_content %}
+<div class="wubet-page container">
+	<div class="intro-card panel panel-default">
+		<div class="panel-heading">
+			<h3 class="panel-title">{{ _("Student Term Subject Results") }}</h3>
+		</div>
+		<div class="panel-body">
+			<p class="text-muted">
+				{{ _("Use this workspace to log scores for each student and automatically create Student Term Subject Result documents.") }}
+			</p>
+			<ul class="help-list">
+				<li>{{ _("Start by selecting a Student Group to load the available students.") }}</li>
+				<li>{{ _("Log each score to the queue, review the list, and submit when you are ready.") }}</li>
+				<li>{{ _("Exam options automatically set the maximum score: First/Second Test (15), Mid Exam (30) and Final Exam (50).") }}</li>
+			</ul>
+		</div>
+	</div>
+
+	<div class="panel panel-default">
+		<div class="panel-heading">
+			<h4 class="panel-title">{{ _("Score Entry") }}</h4>
+		</div>
+		<div class="panel-body">
+			<form id="result-entry-form">
+				<div id="form-feedback" class="alert" style="display: none;"></div>
+
+				<div class="row">
+					<div class="col-md-4 form-group">
+						<label for="student-group">{{ _("Student Group") }}</label>
+						<select class="form-control" id="student-group" required>
+							<option value="">{{ _("Select Student Group") }}</option>
+						</select>
+						<small id="student-loading" class="text-muted" style="display: none;">{{ _("Loading students...") }}</small>
+					</div>
+					<div class="col-md-4 form-group">
+						<label for="student">{{ _("Student") }}</label>
+						<select class="form-control" id="student" disabled required>
+							<option value="">{{ _("Select Student") }}</option>
+						</select>
+					</div>
+					<div class="col-md-4 form-group">
+						<label for="student-name">{{ _("Student Name") }}</label>
+						<input type="text" class="form-control" id="student-name" placeholder="{{ _('Auto-filled after selecting a student') }}" readonly>
+					</div>
+				</div>
+
+				<div class="row">
+					<div class="col-md-4 form-group">
+						<label for="grade">{{ _("Grade (Program)") }}</label>
+						<select class="form-control" id="grade" required>
+							<option value="">{{ _("Select Grade / Program") }}</option>
+						</select>
+					</div>
+					<div class="col-md-4 form-group">
+						<label for="subject">{{ _("Subject") }}</label>
+						<select class="form-control" id="subject" required>
+							<option value="">{{ _("Select Subject") }}</option>
+						</select>
+					</div>
+					<div class="col-md-4 form-group">
+						<label for="academic-year">{{ _("Academic Year") }}</label>
+						<input type="text" class="form-control" id="academic-year">
+					</div>
+				</div>
+
+				<div class="row">
+					<div class="col-md-4 form-group">
+						<label for="semester">{{ _("Semester") }}</label>
+						<select class="form-control" id="semester" required></select>
+					</div>
+					<div class="col-md-4 form-group">
+						<label for="exam">{{ _("Exam") }}</label>
+						<select class="form-control" id="exam" required>
+							<option value="">{{ _("Select Exam") }}</option>
+						</select>
+					</div>
+					<div class="col-md-2 form-group">
+						<label for="max-score">{{ _("Maximum Score") }}</label>
+						<input type="number" class="form-control" id="max-score" readonly>
+					</div>
+					<div class="col-md-2 form-group">
+						<label for="score">{{ _("Score") }}</label>
+						<input type="number" class="form-control" id="score" min="0" step="0.01" required>
+					</div>
+				</div>
+
+				<div class="form-actions">
+					<button type="button" class="btn btn-default" id="clear-form-btn">{{ _("Reset Form") }}</button>
+					<button type="button" class="btn btn-primary" id="log-score-btn">
+						{{ _("Log Score") }}
+					</button>
+					<button type="button" class="btn btn-success pull-right" id="submit-scores-btn" disabled>
+						{{ _("Submit Logged Scores") }}
+					</button>
+				</div>
+			</form>
+		</div>
+	</div>
+
+	<div class="panel panel-default">
+		<div class="panel-heading">
+			<h4 class="panel-title">{{ _("Queued Scores") }}</h4>
+		</div>
+		<div class="panel-body table-responsive">
+			<table class="table table-bordered table-condensed">
+				<thead>
+					<tr>
+						<th>{{ _("Academic Year") }}</th>
+						<th>{{ _("Semester") }}</th>
+						<th>{{ _("Student Group") }}</th>
+						<th>{{ _("Student") }}</th>
+						<th>{{ _("Student Name") }}</th>
+						<th>{{ _("Grade") }}</th>
+						<th>{{ _("Subject") }}</th>
+						<th>{{ _("Exam") }}</th>
+						<th class="text-right">{{ _("Score") }}</th>
+						<th class="text-right">{{ _("Max Score") }}</th>
+						<th>{{ _("Actions") }}</th>
+					</tr>
+				</thead>
+				<tbody id="logged-entries-body">
+					<tr id="no-entries-row">
+						<td colspan="11" class="text-center text-muted">
+							{{ _("No scores queued yet. Log a score to get started.") }}
+						</td>
+					</tr>
+				</tbody>
+			</table>
+			<div id="submission-summary" style="display: none;"></div>
+		</div>
+	</div>
+</div>
+{% endblock %}
+
+{% block style %}
+<style>
+	.wubet-page .panel {
+		box-shadow: none;
+	}
+	.wubet-page .help-list {
+		margin-bottom: 0;
+	}
+	.wubet-page .form-actions {
+		display: flex;
+		gap: 10px;
+		align-items: center;
+		margin-top: 15px;
+	}
+	.wubet-page .form-actions .btn {
+		min-width: 140px;
+	}
+	.wubet-page .table td {
+		vertical-align: middle;
+	}
+	.wubet-page .remove-entry-btn {
+		min-width: 80px;
+	}
+	#submission-summary .alert {
+		margin-bottom: 0;
+	}
+</style>
+{% endblock %}
+
+{% block script %}
+<script>
+	const wubetBoot = {{ wubet_boot | safe }};
+	const state = {
+		loggedEntries: []
+	};
+
+	const elements = {};
+	const examScoreMap = {};
+
+	document.addEventListener("DOMContentLoaded", () => {
+		cacheElements();
+		populateStaticSelects();
+		registerListeners();
+		setDefaultValues();
+	});
+
+	function cacheElements() {
+		elements.form = document.getElementById("result-entry-form");
+		elements.feedback = document.getElementById("form-feedback");
+		elements.studentGroup = document.getElementById("student-group");
+		elements.student = document.getElementById("student");
+		elements.studentName = document.getElementById("student-name");
+		elements.grade = document.getElementById("grade");
+		elements.subject = document.getElementById("subject");
+		elements.academicYear = document.getElementById("academic-year");
+		elements.semester = document.getElementById("semester");
+		elements.exam = document.getElementById("exam");
+		elements.maxScore = document.getElementById("max-score");
+		elements.score = document.getElementById("score");
+		elements.logButton = document.getElementById("log-score-btn");
+		elements.submitButton = document.getElementById("submit-scores-btn");
+		elements.clearButton = document.getElementById("clear-form-btn");
+		elements.entriesBody = document.getElementById("logged-entries-body");
+		elements.noEntriesRow = document.getElementById("no-entries-row");
+		elements.studentLoading = document.getElementById("student-loading");
+		elements.summary = document.getElementById("submission-summary");
+	}
+
+	function populateStaticSelects() {
+		(wubetBoot.exam_options || []).forEach(option => {
+			examScoreMap[option.value] = option.max_score;
+			addOption(elements.exam, option.value, option.label);
+		});
+
+		addOption(elements.semester, "", __("Select Semester"));
+		(wubetBoot.semesters || []).forEach(option => {
+			addOption(elements.semester, option.value, option.label);
+		});
+
+		(wubetBoot.grades || []).forEach(grade => {
+			const label = grade.program_name || grade.name;
+			addOption(elements.grade, grade.name, label);
+		});
+
+		(wubetBoot.subjects || []).forEach(subject => {
+			const label = subject.course_name || subject.name;
+			addOption(elements.subject, subject.name, label);
+		});
+
+		(wubetBoot.student_groups || []).forEach(group => {
+			const label = group.student_group_name || group.name;
+			const option = addOption(elements.studentGroup, group.name, label);
+			option.dataset.program = group.program || "";
+		});
+	}
+
+	function registerListeners() {
+		elements.form.addEventListener("submit", evt => evt.preventDefault());
+		elements.studentGroup.addEventListener("change", handleStudentGroupChange);
+		elements.student.addEventListener("change", handleStudentChange);
+		elements.exam.addEventListener("change", handleExamChange);
+		elements.score.addEventListener("input", handleScoreInput);
+		elements.logButton.addEventListener("click", logScore);
+		elements.submitButton.addEventListener("click", submitLoggedScores);
+		elements.clearButton.addEventListener("click", resetForm);
+	}
+
+	function setDefaultValues() {
+		if (wubetBoot.default_academic_year) {
+			elements.academicYear.value = wubetBoot.default_academic_year;
+		}
+		if (wubetBoot.semesters && wubetBoot.semesters.length) {
+			elements.semester.value = wubetBoot.semesters[0].value;
+		}
+	}
+
+	function addOption(select, value, label) {
+		const option = document.createElement("option");
+		option.value = value;
+		option.textContent = label;
+		select.appendChild(option);
+		return option;
+	}
+
+	function handleStudentGroupChange(event) {
+		const selectedOption = event.target.selectedOptions[0];
+		const program = selectedOption ? selectedOption.dataset.program : "";
+		if (program) {
+			elements.grade.value = program;
+		}
+		loadStudentsForGroup(event.target.value);
+	}
+
+	function handleStudentChange(event) {
+		const selectedOption = event.target.selectedOptions[0];
+		elements.studentName.value = selectedOption ? selectedOption.dataset.studentName || "" : "";
+	}
+
+	function handleExamChange(event) {
+		const exam = event.target.value;
+		elements.maxScore.value = exam ? (examScoreMap[exam] || "") : "";
+		handleScoreInput();
+	}
+
+	function handleScoreInput() {
+		const max = parseFloat(elements.maxScore.value || "0");
+		const score = parseFloat(elements.score.value || "0");
+		if (max && score > max) {
+			elements.score.setCustomValidity("Score cannot exceed maximum score.");
+		} else {
+			elements.score.setCustomValidity("");
+		}
+	}
+
+	function resetForm() {
+		elements.form.reset();
+		setDefaultValues();
+		elements.student.innerHTML = `<option value="">${__("Select Student")}</option>`;
+		elements.student.disabled = true;
+		elements.studentName.value = "";
+		elements.maxScore.value = "";
+		clearFeedback();
+	}
+
+	function loadStudentsForGroup(studentGroup) {
+		elements.student.innerHTML = `<option value="">${__("Select Student")}</option>`;
+		elements.student.disabled = true;
+		elements.studentName.value = "";
+
+		if (!studentGroup) {
+			return;
+		}
+
+		elements.studentLoading.style.display = "inline";
+		const request = frappe.call({
+			method: "education.education.api.get_students_for_group",
+			args: { student_group: studentGroup },
+			callback: response => {
+				const students = (response && response.message) || [];
+				students.forEach(student => {
+					const label = `${student.student} - ${student.student_name}`;
+					const option = addOption(elements.student, student.student, label);
+					option.dataset.studentName = student.student_name || "";
+				});
+				elements.student.disabled = students.length === 0;
+				if (students.length === 0) {
+					showFeedback(__("No students found for the selected group."), "warning");
+				} else {
+					clearFeedback();
+				}
+				elements.studentLoading.style.display = "none";
+			},
+			error: () => {
+				showFeedback(__("Unable to load students. Please try again."), "danger");
+				elements.studentLoading.style.display = "none";
+			}
+		});
+	}
+
+	function validateEntry() {
+		const errors = [];
+		const entry = {
+			student_group: elements.studentGroup.value,
+			student: elements.student.value,
+			student_name: elements.studentName.value,
+			grade: elements.grade.value,
+			subject: elements.subject.value,
+			academic_year: elements.academicYear.value.trim(),
+			semester: elements.semester.value,
+			exam: elements.exam.value,
+			max_score: parseFloat(elements.maxScore.value || "0"),
+			score: parseFloat(elements.score.value || "0")
+		};
+
+		if (!entry.student_group) errors.push(__("Student Group is required."));
+		if (!entry.student) errors.push(__("Student is required."));
+		if (!entry.grade) errors.push(__("Grade / Program is required."));
+		if (!entry.subject) errors.push(__("Subject is required."));
+		if (!entry.academic_year) errors.push(__("Academic Year is required."));
+		if (!entry.semester) errors.push(__("Semester is required."));
+		if (!entry.exam) errors.push(__("Exam is required."));
+		if (!entry.max_score) errors.push(__("Maximum Score is required. Select an exam to set it automatically."));
+		if (!entry.score && entry.score !== 0) {
+			errors.push(__("Score is required."));
+		} else if (entry.max_score && entry.score > entry.max_score) {
+			errors.push(__("Score cannot exceed Maximum Score."));
+		}
+
+		if (errors.length) {
+			showFeedback(errors.join(" "), "danger");
+			return null;
+		}
+
+		entry.section = entry.student_group;
+		return entry;
+	}
+
+	function logScore() {
+		const entry = validateEntry();
+		if (!entry) {
+			return;
+		}
+
+		const displayEntry = {
+			...entry,
+			student_label: elements.student.selectedOptions[0]?.textContent || entry.student,
+			subject_label: elements.subject.selectedOptions[0]?.textContent || entry.subject,
+			grade_label: elements.grade.selectedOptions[0]?.textContent || entry.grade
+		};
+
+		state.loggedEntries.push(displayEntry);
+		renderEntries();
+		showFeedback(__("Score added to the queue. Remember to submit logged scores."), "success");
+		enableSubmit();
+		elements.score.value = "";
+	}
+
+	function renderEntries() {
+		elements.entriesBody.innerHTML = "";
+		if (!state.loggedEntries.length) {
+			elements.entriesBody.appendChild(elements.noEntriesRow);
+			elements.noEntriesRow.style.display = "table-row";
+			disableSubmit();
+			elements.summary.style.display = "none";
+			elements.summary.innerHTML = "";
+			return;
+		}
+
+		elements.noEntriesRow.style.display = "none";
+		state.loggedEntries.forEach((entry, index) => {
+			const row = document.createElement("tr");
+			row.innerHTML = `
+				<td>${entry.academic_year}</td>
+				<td>${entry.semester}</td>
+				<td>${entry.student_group}</td>
+				<td>${entry.student}</td>
+				<td>${entry.student_name || ""}</td>
+				<td>${entry.grade_label || entry.grade}</td>
+				<td>${entry.subject_label || entry.subject}</td>
+				<td>${entry.exam}</td>
+				<td class="text-right">${formatNumber(entry.score)}</td>
+				<td class="text-right">${formatNumber(entry.max_score)}</td>
+				<td class="text-center">
+					<button type="button" class="btn btn-xs btn-danger remove-entry-btn" data-index="${index}">
+						${__("Remove")}
+					</button>
+				</td>
+			`;
+			row.querySelector(".remove-entry-btn").addEventListener("click", () => removeEntry(index));
+			elements.entriesBody.appendChild(row);
+		});
+	}
+
+	function removeEntry(index) {
+		state.loggedEntries.splice(index, 1);
+		renderEntries();
+		if (state.loggedEntries.length) {
+			showFeedback(__("Entry removed."), "info");
+		} else {
+			clearFeedback();
+		}
+	}
+
+	function enableSubmit() {
+		elements.submitButton.disabled = state.loggedEntries.length === 0;
+	}
+
+	function disableSubmit() {
+		elements.submitButton.disabled = true;
+	}
+
+	function formatNumber(number) {
+		return (Number(number || 0)).toFixed(2);
+	}
+
+	async function submitLoggedScores() {
+		if (!state.loggedEntries.length) {
+			showFeedback(__("No scores to submit."), "warning");
+			return;
+		}
+
+		disableButtons(true);
+		showFeedback(__("Submitting scores..."), "info");
+
+		const summary = {
+			success: [],
+			failed: []
+		};
+
+		for (const entry of state.loggedEntries) {
+			try {
+				await callCreateResult(entry);
+				summary.success.push(entry);
+			} catch (error) {
+				summary.failed.push({ entry, error: parseError(error) });
+			}
+		}
+
+		disableButtons(false);
+		handleSubmissionSummary(summary);
+	}
+
+	function disableButtons(isDisabled) {
+		elements.logButton.disabled = isDisabled;
+		elements.submitButton.disabled = isDisabled;
+		elements.clearButton.disabled = isDisabled;
+	}
+
+	function callCreateResult(entry) {
+		return new Promise((resolve, reject) => {
+			frappe.call({
+				method: "education.education.api.create_and_submit_term_subject_result",
+				args: { data: JSON.stringify(entry) },
+				callback: response => {
+					if (response && response.exc) {
+						reject(response.exc);
+					} else {
+						resolve(response.message);
+					}
+				},
+				error: error => reject(error)
+			});
+		});
+	}
+
+	function parseError(error) {
+		if (!error) return __("Unexpected error");
+		if (typeof error === "string") return error;
+		if (error._server_messages) {
+			try {
+				const messages = JSON.parse(error._server_messages);
+				return messages.map(msg => {
+					try {
+						return JSON.parse(msg).message || msg;
+					} catch (e) {
+						return msg;
+					}
+				}).join(" ");
+			} catch (e) {
+				return error._server_messages;
+			}
+		}
+		if (error.message) return error.message;
+		return __("Failed to submit entry");
+	}
+
+	function handleSubmissionSummary(summary) {
+		let summaryHtml = "";
+		if (summary.success.length) {
+			const count = summary.success.length;
+			summaryHtml += `<div class="alert alert-success">${__("Submitted {0} score(s) successfully.", [count])}</div>`;
+		}
+		if (summary.failed.length) {
+			const details = summary.failed.map(item => {
+				const student = item.entry.student_name || item.entry.student;
+				return `<li><strong>${escapeHtml(student)}</strong>: ${escapeHtml(item.error)}</li>`;
+			}).join("");
+			summaryHtml += `
+				<div class="alert alert-warning">
+					<p>${__("Some submissions failed:")}</p>
+					<ul>${details}</ul>
+				</div>`;
+		}
+
+		elements.summary.innerHTML = summaryHtml;
+		elements.summary.style.display = summaryHtml ? "block" : "none";
+
+		if (summary.failed.length === 0) {
+			state.loggedEntries = [];
+			renderEntries();
+			showFeedback(__("All scores were submitted successfully."), "success");
+		} else if (summary.success.length) {
+			state.loggedEntries = summary.failed.map(item => item.entry);
+			renderEntries();
+			showFeedback(__("Some scores failed to submit. Please review the messages below."), "warning");
+		} else {
+			showFeedback(__("Unable to submit any of the queued scores."), "danger");
+		}
+	}
+
+	function showFeedback(message, level) {
+		elements.feedback.className = `alert alert-${level}`;
+		elements.feedback.textContent = message;
+		elements.feedback.style.display = "block";
+	}
+
+	function clearFeedback() {
+		elements.feedback.style.display = "none";
+		elements.feedback.textContent = "";
+	}
+
+	function escapeHtml(value) {
+		const div = document.createElement("div");
+		div.textContent = value || "";
+		return div.innerHTML;
+	}
+</script>
+{% endblock %}

--- a/education/www/wubet.html
+++ b/education/www/wubet.html
@@ -206,6 +206,16 @@
 			border-color: #2563eb;
 			box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
 		}
+
+		.debug-panel {
+			background: #0f172a;
+			color: #facc15;
+			border-radius: 8px;
+			padding: 12px;
+			font-size: 12px;
+			max-height: 240px;
+			overflow-y: auto;
+		}
 	</style>
 </head>
 <body>
@@ -324,6 +334,10 @@
 				</table>
 			</div>
 			<div id="submission-summary" style="margin-top: 16px; display: none;"></div>
+			<div id="debug-panel" class="debug-panel" style="display:none;">
+				<h4>{{ _("Debug Info") }}</h4>
+				<pre id="debug-log" style="white-space:pre-wrap;"></pre>
+			</div>
 		</section>
 	</div>
 
@@ -342,6 +356,7 @@
 			entryRemoved: "Entry removed.",
 			noEntriesSubmit: "No scores to submit.",
 			noStudentScores: "Enter a score for at least one student before logging.",
+			scoreSaveError: "Failed to save score entry.",
 			submitting: "Submitting scores...",
 			submittedTemplate: "Submitted {0} score(s) successfully.",
 			someFailed: "Some submissions failed:",
@@ -437,6 +452,16 @@
 			elements.clearButton.addEventListener("click", resetForm);
 		}
 
+		function logDebug(message, payload) {
+			const panel = document.getElementById("debug-panel");
+			const pre = document.getElementById("debug-log");
+			if (!panel || !pre) return;
+			panel.style.display = "block";
+			const timestamp = new Date().toISOString();
+			const serialized = payload ? JSON.stringify(payload, null, 2) : "";
+			pre.textContent = `${timestamp} | ${message}\n${serialized}\n\n${pre.textContent}`.trim();
+		}
+
 		function getScoreContextParams() {
 			return {
 				student_group: elements.studentGroup.value,
@@ -501,6 +526,7 @@
 					},
 					{ method: "GET" }
 				);
+				logDebug("Fetched existing drafts", { params, records });
 				state.studentScores = {};
 				state.resultDocs = {};
 				state.lastQueuedScores = {};
@@ -604,6 +630,7 @@
 					{ student_group: studentGroup },
 					{ method: "GET" }
 				);
+				logDebug("Loaded students", { student_group: studentGroup, count: (students || []).length });
 				state.students = students || [];
 				renderStudentsTable();
 				if (!state.students.length) {
@@ -911,12 +938,14 @@
 			showFeedback(TEXT.submitting, "info");
 
 			const summary = { success: [], failed: [] };
+			logDebug("Submitting queued scores", state.loggedEntries);
 
 			for (const entry of state.loggedEntries) {
 				try {
 					await callCreateResult(entry);
 					summary.success.push(entry);
 				} catch (error) {
+					logDebug("Failed to save score", { entry, error: error.message || error });
 					summary.failed.push({ entry, error: error.message || error });
 				}
 			}
@@ -947,6 +976,12 @@
 				examiner: entry.examiner || ""
 			};
 
+			logDebug("Saving score", {
+				method: entry.name ? "PUT" : "POST",
+				entry,
+				payload
+			});
+
 			let response;
 			if (entry.name) {
 				response = await apiCall(
@@ -955,17 +990,20 @@
 					{ method: "PUT" }
 				);
 			} else {
+				const body = { doctype: "Student Term Subject Result", ...payload };
 				response = await apiCall(
 					"/api/resource/Student Term Subject Result",
-					{ doctype: "Student Term Subject Result", ...payload },
+					body,
 					{ method: "POST" }
 				);
 			}
+			logDebug("API response", { entry, payload, response });
 
 			const docName = response && response.name;
 			if (docName) {
 				const key = buildScoreKey(entry.student, entry.subject, entry.exam, entry.academic_year, entry.semester);
 				state.resultDocs[key] = docName;
+				entry.name = docName;
 				state.studentScores[entry.student] = {
 					student: entry.student,
 					student_name: entry.student_name,
@@ -1049,6 +1087,7 @@
 
 			if (!response.ok || data.exc) {
 				const errorMessage = extractErrorMessage(data) || `${response.status} ${response.statusText}`;
+				logDebug("API error", { url, method, payload, status: response.status, response: data });
 				throw new Error(errorMessage);
 			}
 

--- a/education/www/wubet.py
+++ b/education/www/wubet.py
@@ -1,0 +1,47 @@
+import frappe
+from frappe import _
+
+
+def get_context(context):
+    context.title = _("Student Result Entry")
+
+    default_academic_year = "2018 E.C."
+    semester_options = [
+        {"label": "2018 E.C. (First Semester)", "value": "2018 E.C. (First Semester)"},
+        {"label": "2018 E.C. (Second Semester)", "value": "2018 E.C. (Second Semester)"},
+    ]
+    exam_options = [
+        {"label": "First Test", "value": "First Test", "max_score": 15},
+        {"label": "Second Test", "value": "Second Test", "max_score": 15},
+        {"label": "Mid Exam", "value": "Mid Exam", "max_score": 30},
+        {"label": "Final Exam", "value": "Final Exam", "max_score": 50},
+    ]
+
+    student_groups = frappe.get_all(
+        "Student Group",
+        fields=["name", "student_group_name", "program"],
+        order_by="student_group_name",
+    )
+    subjects = frappe.get_all(
+        "Course",
+        fields=["name", "course_name"],
+        order_by="course_name",
+    )
+    grades = frappe.get_all(
+        "Program",
+        fields=["name", "program_name"],
+        order_by="program_name",
+    )
+
+    context.wubet_boot = frappe.as_json(
+        {
+            "student_groups": student_groups,
+            "subjects": subjects,
+            "grades": grades,
+            "default_academic_year": default_academic_year,
+            "semesters": semester_options,
+            "exam_options": exam_options,
+        }
+    )
+
+    return context


### PR DESCRIPTION
Add a new web page at `/wubet` to facilitate logging and batch submission of Student Term Subject Results.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fbdfe56-600e-4f51-b936-2a80a45c0137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4fbdfe56-600e-4f51-b936-2a80a45c0137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a `/wubet` page to queue and submit Student Term Subject Results, backed by new create/update and bulk-save APIs with draft fetching.
> 
> - **Frontend (web UI)**:
>   - Add `education/www/wubet.html`: interactive page to select `student_group`/`subject`/`academic_year`/`semester`/`exam`, enter per-student scores, queue entries, and submit in bulk; fetches existing draft results; includes CSRF handling and debug panel.
>   - Add `education/www/wubet.py`: supplies boot data (`student_groups`, `subjects`, `grades`, default year, `semesters`, `exam_options`).
> - **Backend (APIs)**:
>   - In `education/education/api.py` add whitelisted endpoints:
>     - `create_student_term_subject_result(result_data)` to create/update (and optionally submit) a single `Student Term Subject Result`.
>     - `save_student_term_subject_results(entries)` for bulk create/update, returning `success`/`failed` summaries.
>     - `get_student_group_scores(student_group, academic_year, semester, subject, exam)` to fetch draft scores.
>     - Helper `_save_single_student_result(data)`; minor import update to include `cint`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75d14652d559797786940cf40f4474d699f025f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->