### PR TITLE
Missing student group nursery

### DIFF
--- a/education/www/wubet.py
+++ b/education/www/wubet.py
@@ -33,6 +33,7 @@ def get_context(context):
         "Student Group",
         fields=["name", "student_group_name", "program"],
         order_by="student_group_name",
+        limit_page_length=0,
     )
     
     # Get all courses with their associated programs for filtering
@@ -40,16 +41,18 @@ def get_context(context):
         "Course",
         fields=["name", "course_name"],
         order_by="course_name",
+        limit_page_length=0,
     )
     
     # Get program courses mapping
     program_courses = {}
-    for program in frappe.get_all("Program", fields=["name"]):
+    for program in frappe.get_all("Program", fields=["name"], limit_page_length=0):
         courses = frappe.get_all(
             "Program Course",
             filters={"parent": program.name},
             fields=["course"],
-            pluck="course"
+            pluck="course",
+            limit_page_length=0,
         )
         program_courses[program.name] = courses
     
@@ -57,6 +60,7 @@ def get_context(context):
         "Program",
         fields=["name", "program_name"],
         order_by="program_name",
+        limit_page_length=0,
     )
 
     context.wubet_boot = frappe.as_json(


### PR DESCRIPTION
Update `/wubet` to fetch all Student Groups and related lists to prevent truncation.

Frappe's `frappe.get_all()` defaults to a 20-record limit, which caused the "Student Groups" dropdown on the `/wubet` page to be incomplete, omitting entries like "Nursery I". Setting `limit_page_length=0` ensures all records are retrieved.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb3f91f7-fb72-4ddd-b093-2126ebf50b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb3f91f7-fb72-4ddd-b093-2126ebf50b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `/wubet` loads full Student Groups, Courses, Programs, and Program Courses by setting `limit_page_length=0` on related `frappe.get_all` queries.
> 
> - **Data fetching in `education/www/wubet.py`**:
>   - Set `limit_page_length=0` for `frappe.get_all` on:
>     - `Student Group` (full list for dropdowns)
>     - `Course` (subjects)
>     - `Program` (for both `program_courses` loop and `grades` list)
>     - `Program Course` (within `program_courses` mapping)
>   - No other logic changes; context boot payload now includes complete datasets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14bac3d8ef9d7de8097b7e0f6012ce96d7a4ed76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->