### PR TITLE
Student age calculation

### DIFF
--- a/education/education/doctype/student/student.js
+++ b/education/education/doctype/student/student.js
@@ -27,10 +27,16 @@ frappe.ui.form.on('Student', {
           frm.set_df_property('student_email_id', 'reqd', 1)
         }
       })
+
+    // keep age display in sync on load
+    frm.doc.age = get_age_from_dob(frm.doc.date_of_birth)
+    frm.refresh_field('age')
   },
 
   date_of_birth: function (frm) {
-    frm.set_value('age', get_age_from_dob(frm.doc.date_of_birth))
+    // virtual field: compute for display only (not stored)
+    frm.doc.age = get_age_from_dob(frm.doc.date_of_birth)
+    frm.refresh_field('age')
   },
 })
 
@@ -41,14 +47,10 @@ function get_age_from_dob(dob) {
   const todayDate = frappe.datetime.str_to_obj(frappe.datetime.get_today())
   if (!dobDate || !todayDate) return null
 
-  let age = todayDate.getFullYear() - dobDate.getFullYear()
-  const monthDiff = todayDate.getMonth() - dobDate.getMonth()
-
-  if (monthDiff < 0 || (monthDiff === 0 && todayDate.getDate() < dobDate.getDate())) {
-    age--
-  }
-
-  return Math.max(age, 0)
+  const msPerDay = 24 * 60 * 60 * 1000
+  const ageInYears = (todayDate.getTime() - dobDate.getTime()) / msPerDay / 365.25
+  if (ageInYears < 0) return 0.0
+  return Math.round(ageInYears * 10) / 10
 }
 
 frappe.ui.form.on('Student Guardian', {

--- a/education/education/doctype/student/student.js
+++ b/education/education/doctype/student/student.js
@@ -28,7 +28,28 @@ frappe.ui.form.on('Student', {
         }
       })
   },
+
+  date_of_birth: function (frm) {
+    frm.set_value('age', get_age_from_dob(frm.doc.date_of_birth))
+  },
 })
+
+function get_age_from_dob(dob) {
+  if (!dob) return null
+
+  const dobDate = frappe.datetime.str_to_obj(dob)
+  const todayDate = frappe.datetime.str_to_obj(frappe.datetime.get_today())
+  if (!dobDate || !todayDate) return null
+
+  let age = todayDate.getFullYear() - dobDate.getFullYear()
+  const monthDiff = todayDate.getMonth() - dobDate.getMonth()
+
+  if (monthDiff < 0 || (monthDiff === 0 && todayDate.getDate() < dobDate.getDate())) {
+    age--
+  }
+
+  return Math.max(age, 0)
+}
 
 frappe.ui.form.on('Student Guardian', {
   guardians_add: function (frm) {

--- a/education/education/doctype/student/student.json
+++ b/education/education/doctype/student/student.json
@@ -23,6 +23,7 @@
   "section_break_7",
   "student_email_id",
   "date_of_birth",
+  "age",
   "blood_group",
   "column_break_3",
   "student_mobile_number",
@@ -144,6 +145,12 @@
    "fieldname": "date_of_birth",
    "fieldtype": "Date",
    "label": "Date of Birth"
+  },
+  {
+   "fieldname": "age",
+   "fieldtype": "Int",
+   "label": "Age",
+   "read_only": 1
   },
   {
    "fieldname": "blood_group",

--- a/education/education/doctype/student/student.json
+++ b/education/education/doctype/student/student.json
@@ -148,9 +148,11 @@
   },
   {
    "fieldname": "age",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "label": "Age",
-   "read_only": 1
+   "precision": 1,
+   "read_only": 1,
+   "is_virtual": 1
   },
   {
    "fieldname": "blood_group",

--- a/education/education/doctype/student/student.py
+++ b/education/education/doctype/student/student.py
@@ -17,6 +17,7 @@ class Student(Document):
 	def validate(self):
 		self.set_title()
 		self.validate_dates()
+		self.set_age()
 		self.validate_user()
 
 		if self.student_applicant:
@@ -67,6 +68,21 @@ class Student(Document):
 			and getdate(self.joining_date) > getdate(self.date_of_leaving)
 		):
 			frappe.throw(_("Joining Date can not be greater than Leaving Date"))
+
+	def set_age(self):
+		"""Set age (in years) from date_of_birth."""
+		if not self.date_of_birth:
+			self.age = None
+			return
+
+		dob = getdate(self.date_of_birth)
+		as_on = getdate(today())
+
+		age = as_on.year - dob.year
+		if (as_on.month, as_on.day) < (dob.month, dob.day):
+			age -= 1
+
+		self.age = max(age, 0)
 
 	def validate_user(self):
 		"""Create a website user for student creation if not already exists"""

--- a/education/education/doctype/student/student.py
+++ b/education/education/doctype/student/student.py
@@ -17,7 +17,6 @@ class Student(Document):
 	def validate(self):
 		self.set_title()
 		self.validate_dates()
-		self.set_age()
 		self.validate_user()
 
 		if self.student_applicant:
@@ -69,20 +68,21 @@ class Student(Document):
 		):
 			frappe.throw(_("Joining Date can not be greater than Leaving Date"))
 
-	def set_age(self):
-		"""Set age (in years) from date_of_birth."""
+	def get_age(self):
+		"""Virtual field: dynamically compute age (years) from date_of_birth."""
+		return self._calculate_age_from_dob()
+
+	def _calculate_age_from_dob(self):
 		if not self.date_of_birth:
-			self.age = None
-			return
+			return None
 
 		dob = getdate(self.date_of_birth)
 		as_on = getdate(today())
 
-		age = as_on.year - dob.year
-		if (as_on.month, as_on.day) < (dob.month, dob.day):
-			age -= 1
-
-		self.age = max(age, 0)
+		age_in_years = (as_on - dob).days / 365.25
+		if age_in_years < 0:
+			return 0.0
+		return round(age_in_years, 1)
 
 	def validate_user(self):
 		"""Create a website user for student creation if not already exists"""


### PR DESCRIPTION
Adds a read-only `age` field to the Student DocType, automatically calculated from `date_of_birth`.

The user reported that the `age` field was empty or zero. This PR addresses that by formally defining the `age` field in the DocType, making it read-only, and implementing robust calculation logic on both the client and server. This ensures the age is correctly populated and updated, regardless of whether the student record is created/modified via the UI, API, or imports.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a9376d6-8c04-4be7-bd48-ea5f5c058c64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a9376d6-8c04-4be7-bd48-ea5f5c058c64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a computed age display for students without persisting it to the DB.
> 
> - Defines virtual, read-only Float `age` (precision 1) in `student.json`
> - Computes and refreshes `age` on load and `date_of_birth` change in `student.js` via `get_age_from_dob`
> - Adds server-side `get_age()` and `_calculate_age_from_dob()` in `student.py` to compute age consistently for API/import use
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd9162aba0d136deab826b79a1ff26ebea409241. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->