### PR TITLE
Student group editable grids

### DIFF
--- a/education/education/doctype/student_group/student_group.json
+++ b/education/education/doctype/student_group/student_group.json
@@ -6,6 +6,7 @@
  "creation": "2015-09-07 12:55:52.072792",
  "doctype": "DocType",
  "document_type": "Document",
+ "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "academic_year",


### PR DESCRIPTION
Add `editable_grid` property to Student Group doctype to enable customizable and editable grids.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f771caff-44df-430e-b3e0-727bf81bad44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f771caff-44df-430e-b3e0-727bf81bad44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

