### PR TITLE
Revamp MBReg1825 + Dembi Dollo registration: existing-student flow, branch, dashboards

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -2059,7 +2059,11 @@ def create_student_application(application_data):
 			school_id = generate_school_id(branch)
 		
 		app_doc.custom_school_id = school_id
-		
+
+		# Branch: auto-derived from the School ID prefix (MB/DD, M2) with an
+		# optional explicit override passed from the form (second-branch choice).
+		app_doc.branch = _derive_branch(school_id, application_data.get("branch"))
+
 		# Handle student email based on applicant type
 		if application_data.get("applicant_type") == "Existing":
 			# For existing students, use their existing email if available
@@ -2116,10 +2120,19 @@ def create_student_application(application_data):
 			sibling_row.student_name = sibling.get("student_name")
 			sibling_row.program = sibling.get("program")
 			sibling_row.academic_year = sibling.get("academic_year")
-		
+
+		# Suggested Student Group (gender-balanced round-robin). Non-binding;
+		# a human still does the final enrollment.
+		try:
+			app_doc.suggested_student_section = _suggest_section(
+				app_doc.program, gender=app_doc.gender
+			)
+		except Exception:
+			app_doc.suggested_student_section = ""
+
 		app_doc.insert()
 		return app_doc.name
-		
+
 	except Exception as e:
 		error_msg = str(e)
 		frappe.log_error(message=f"Student application creation failed: {error_msg}\nData: {application_data}", title="Student Application Creation Error")
@@ -2156,6 +2169,7 @@ def update_student_application(application_id, application_data):
 		app_doc.middle_name = application_data.get("middle_name")
 		app_doc.last_name = application_data.get("last_name")
 		app_doc.custom_school_id = application_data.get("custom_school_id")
+		app_doc.branch = _derive_branch(application_data.get("custom_school_id"), application_data.get("branch"))
 		app_doc.program = application_data.get("program")
 		app_doc.academic_year = application_data.get("academic_year")
 		
@@ -2309,6 +2323,8 @@ def generate_application_pdf(application_id):
         # Convert app_doc to a format similar to the session data structure
         app_data = {
             'submittedApplicationId': app_doc.name,
+            'branch': app_doc.get('branch') or 'Main',
+            'applicant_type': app_doc.get('applicant_type') or 'New',
             'guardianType': 'parent' if len(app_doc.guardians) >= 2 else 'guardian',
             'studentData': {
                 'first_name': app_doc.first_name or '',
@@ -2489,6 +2505,8 @@ def generate_application_pdf(application_id):
                     <div class='school-name'>Makko Billi School</div>
                     <div class='app-title'>Student Application Form</div>
                     <div class='app-id'>Application ID: {app_data.get('submittedApplicationId', '')}</div>
+                    <div class='app-id' style='background:#dbeafe;color:#1e40af;font-weight:bold;font-size:14px;margin-left:6px;'>School ID: {app_data.get('studentData', {}).get('custom_school_id', '')}</div>
+                    <div class='app-id' style='margin-left:6px;'>Branch: {app_data.get('branch', 'Main')} &nbsp;|&nbsp; Type: {app_data.get('applicant_type', 'New')}</div>
                 </div>
 
                 <div class='main-container'>
@@ -3140,3 +3158,685 @@ def generate_student_report_cards(academic_year, student=None, student_group=Non
         frappe.db.rollback()
         frappe.log_error(frappe.get_traceback(), "Report Card Generation Error")
         return {"action": "Error", "error": str(e)}
+
+
+# ================================================================
+# BRANCH, PROMOTION, EXISTING-STUDENT & SECTION-SUGGESTION API
+# ================================================================
+# Shared by the /mbreg1825 (public) and /apply-dd (Dembi Dollo) registration
+# pages. Everything here is deliberately defensive: the pages call it from
+# guest/registrar contexts, so failures degrade gracefully instead of breaking
+# the multi-step form.
+
+# Roles that receive the 30-minute "new applicants" notification. There is no
+# role literally named "Accountant" on the site, so we target both Accounts
+# roles. Edit this list to change who gets notified - it is pure data.
+ACCOUNTS_NOTIFY_ROLES = ["Accounts Manager", "Accounts User"]
+
+
+def _derive_branch(school_id=None, explicit=None):
+    """Return the canonical Branch value for an applicant.
+
+    Rules (in priority order):
+      - School ID starting with "MB/DD" -> "MBS Dembi Dollo"
+      - School ID starting with "M2/"   -> "MBS #2"
+      - An explicit branch choice from the form (second branch) -> "MBS #2"
+        / Dembi Dollo -> "MBS Dembi Dollo"
+      - Otherwise default to "Main".
+    """
+    sid = (school_id or "").strip().upper()
+    if sid.startswith("MB/DD"):
+        return "MBS Dembi Dollo"
+    if sid.startswith("M2/"):
+        return "MBS #2"
+
+    if explicit:
+        e = str(explicit).strip().lower()
+        if e in ("m2", "mbs #2", "mbs no 2", "mbs no. 2", "mbs number two",
+                 "branch 2", "second branch", "2", "#2"):
+            return "MBS #2"
+        if "dembi" in e or e in ("mb/dd", "dd", "mbs dembi dollo"):
+            return "MBS Dembi Dollo"
+        if e in ("m1", "main", "main branch"):
+            return "Main"
+
+    return "Main"
+
+
+def _split_program_suffix(program):
+    """Split a program like "Grade 8 AO" into ("Grade 8", "AO")."""
+    program = (program or "").strip()
+    match = re_module.search(r"\s+(AO|NS|SS)$", program)
+    if match:
+        return program[: match.start()].strip(), match.group(1)
+    return program, ""
+
+
+def _resolve_program(base, suffix):
+    """Return the best existing Program name for a base + optional suffix.
+
+    Prefers the suffixed program (e.g. "Grade 9 AO"); falls back to the base
+    program (e.g. "Grade 10" when "Grade 10 AO" does not exist).
+    """
+    candidates = []
+    if suffix:
+        candidates.append(f"{base} {suffix}")
+    candidates.append(base)
+    for candidate in candidates:
+        if frappe.db.exists("Program", candidate):
+            return candidate
+    return candidates[0]
+
+
+def _compute_next_program(current_program):
+    """Compute the program a *promoted* student advances into.
+
+    Sequence: Nursery -> LKG -> UKG -> Grade 1 -> ... -> Grade 12.
+    The medium suffix (AO) is preserved where the target program exists.
+    Grades 11/12 use the NS stream by default (only NS/SS streams exist there).
+    Returns None when the student has graduated (Grade 12).
+    """
+    base, suffix = _split_program_suffix(current_program)
+
+    early = {"Nursery": "LKG", "LKG": "UKG", "UKG": "Grade 1"}
+    if base in early:
+        return _resolve_program(early[base], suffix)
+
+    grade_match = re_module.match(r"^Grade\s+(\d+)$", base)
+    if grade_match:
+        current_grade = int(grade_match.group(1))
+        if current_grade >= 12:
+            return None  # graduated
+        next_grade = current_grade + 1
+        # Streams (NS/SS) start at Grade 11; default to NS when none chosen.
+        if next_grade >= 11 and not suffix:
+            suffix = "NS"
+        return _resolve_program(f"Grade {next_grade}", suffix)
+
+    # Unknown program shape: best effort, keep them where they are.
+    return current_program
+
+
+def _get_not_promoted_record(school_id, academic_year=None):
+    """Return a Not Promoted Student record for this school ID, or None."""
+    if not school_id:
+        return None
+    filters = {"school_id": school_id.strip()}
+    if academic_year:
+        filters["academic_year"] = academic_year
+    rows = frappe.get_all(
+        "Not Promoted Student",
+        filters=filters,
+        fields=["name", "reason", "current_program", "academic_year"],
+        order_by="modified desc",
+        limit=1,
+        ignore_permissions=True,
+    )
+    return rows[0] if rows else None
+
+
+@frappe.whitelist(allow_guest=True)
+def get_next_program(current_program, school_id=None, academic_year=None):
+    """Public helper: given a student's current program, return their next one.
+
+    If the student's School ID appears in the Not Promoted Student list they are
+    treated as *not promoted* (they repeat the current program).
+    """
+    not_promoted = _get_not_promoted_record(school_id, academic_year)
+    if not_promoted:
+        return {
+            "promoted": False,
+            "next_program": current_program,
+            "reason": not_promoted.get("reason") or "",
+        }
+    return {
+        "promoted": True,
+        "next_program": _compute_next_program(current_program),
+        "reason": "",
+    }
+
+
+def _get_student_current_enrollment(student_name):
+    """Return (program, student_group) for a Student's most recent enrollment."""
+    rows = frappe.get_all(
+        "Program Enrollment",
+        filters={"student": student_name},
+        fields=["name", "program", "academic_year"],
+        order_by="creation desc",
+        limit=1,
+        ignore_permissions=True,
+    )
+    if not rows:
+        return None, None
+    program = rows[0].program
+    group = frappe.db.get_value(
+        "Student Group Student",
+        {"student": student_name},
+        "parent",
+        order_by="creation desc",
+    )
+    return program, group
+
+
+def _guardian_details(guardian_name):
+    """Return a flat dict of a Guardian's editable details."""
+    if not guardian_name or not frappe.db.exists("Guardian", guardian_name):
+        return {}
+    g = frappe.get_doc("Guardian", guardian_name)
+    return {
+        "guardian": g.name,
+        "guardian_name": g.guardian_name or "",
+        "mobile_number": g.mobile_number or "",
+        "alternate_number": g.get("alternate_number") or "",
+        "email_address": g.get("email_address") or "",
+        "education": g.get("education") or "",
+        "occupation": g.get("occupation") or "",
+        "work_address": g.get("work_address") or "",
+        "image": g.get("image") or "",
+    }
+
+
+@frappe.whitelist(allow_guest=True)
+def get_existing_student_details(school_id):
+    """Fetch a full existing-student profile for the "Existing Student" flow.
+
+    Returns the student's picture, full name, personal + address details, the
+    linked guardians (with editable details), the current grade/section, and a
+    computed promotion decision. ``can_continue`` is True only when the student
+    is promoted AND not restricted.
+    """
+    if not school_id:
+        return {"found": False, "message": "Please enter a School ID."}
+
+    school_id = school_id.strip()
+    student_name = frappe.db.get_value("Student", {"custom_school_id": school_id}, "name")
+    if not student_name:
+        return {
+            "found": False,
+            "message": "No existing student found with this School ID.",
+        }
+
+    student = frappe.get_doc("Student", student_name)
+
+    # Guardians (from the student's own guardian table)
+    guardians = []
+    for row in student.get("guardians", []):
+        details = _guardian_details(row.guardian)
+        if details:
+            details["relation"] = row.get("relation") or ""
+            guardians.append(details)
+
+    current_program, current_group = _get_student_current_enrollment(student_name)
+
+    # Promotion decision
+    not_promoted = _get_not_promoted_record(school_id)
+    is_promoted = not bool(not_promoted)
+    is_restricted = bool(student.get("restricted"))
+    next_program = current_program if not is_promoted else _compute_next_program(current_program)
+    suggested_section = _suggest_section(next_program, gender=student.get("gender"),
+                                         prev_section=current_group)
+
+    can_continue = is_promoted and not is_restricted
+
+    block_reason = ""
+    if is_restricted:
+        block_reason = student.get("reason_for_restriction") or "This student is restricted."
+    elif not is_promoted:
+        block_reason = (not_promoted.get("reason")
+                        or "This student was not promoted and cannot re-apply online.")
+
+    return {
+        "found": True,
+        "student": student_name,
+        "custom_school_id": school_id,
+        "branch": _derive_branch(school_id),
+        "first_name": student.first_name or "",
+        "middle_name": student.middle_name or "",
+        "last_name": student.last_name or "",
+        "student_name": student.student_name or "",
+        "image": student.image or "",
+        "gender": student.gender or "",
+        "date_of_birth": str(student.date_of_birth) if student.date_of_birth else "",
+        "student_mobile_number": student.student_mobile_number or "",
+        "student_email_id": student.student_email_id or "",
+        "national_id_fin": student.get("national_id_fin") or "",
+        "nationality": student.get("nationality") or "Ethiopian",
+        "address_line_1": student.get("address_line_1") or "",
+        "address_line_2": student.get("address_line_2") or "",
+        "kebele": student.get("kebele") or "",
+        "sub_city": student.get("sub_city") or "",
+        "city": student.get("city") or "",
+        "state": student.get("state") or "",
+        "country": student.get("country") or "Ethiopia",
+        "pincode": student.get("pincode") or "",
+        "guardians": guardians,
+        "current_program": current_program or "",
+        "current_section": current_group or "",
+        "is_promoted": is_promoted,
+        "is_restricted": is_restricted,
+        "next_program": next_program or "",
+        "suggested_section": suggested_section or "",
+        "can_continue": can_continue,
+        "block_reason": block_reason,
+    }
+
+
+def _suggest_section(program, gender=None, prev_section=None):
+    """Suggest a Student Group for an applicant.
+
+    - Existing students (prev_section given): carry the section letter forward,
+      e.g. "Grade 7 A" -> the "... A" group of the next program when it exists.
+    - New students: gender-balanced round-robin across the program's active
+      groups (fewest members first, then fewest of the same gender).
+    Returns a Student Group name, or "" when none can be suggested.
+    """
+    if not program:
+        return ""
+
+    active_groups = frappe.get_all(
+        "Student Group",
+        filters={"program": program, "disabled": 0},
+        fields=["name"],
+        order_by="name asc",
+        ignore_permissions=True,
+    )
+    group_names = [g.name for g in active_groups]
+    if not group_names:
+        return ""
+
+    # Existing student: keep the same section letter if the next program has it.
+    if prev_section:
+        letter = prev_section.strip().split(" ")[-1]
+        for name in group_names:
+            if name.strip().split(" ")[-1] == letter:
+                return name
+        # fall through to balancing if the letter has no counterpart
+
+    # New student: balance by current suggested-section load + gender.
+    existing = frappe.get_all(
+        "Student Applicant",
+        filters={"program": program, "suggested_student_section": ["in", group_names]},
+        fields=["suggested_student_section", "gender"],
+        ignore_permissions=True,
+    )
+    total_counts = {name: 0 for name in group_names}
+    gender_counts = {name: 0 for name in group_names}
+    for row in existing:
+        grp = row.suggested_student_section
+        if grp in total_counts:
+            total_counts[grp] += 1
+            if gender and row.gender == gender:
+                gender_counts[grp] += 1
+
+    # Pick the group with the fewest total members; break ties by fewest of the
+    # applicant's gender, then by name for determinism.
+    best = sorted(
+        group_names,
+        key=lambda name: (total_counts[name], gender_counts[name], name),
+    )
+    return best[0]
+
+
+@frappe.whitelist(allow_guest=True)
+def suggest_student_section(program, gender=None, prev_section=None):
+    """Whitelisted wrapper around :func:`_suggest_section`."""
+    return _suggest_section(program, gender=gender, prev_section=prev_section)
+
+
+def _sync_guardian(guardian_data):
+    """Create or update a Guardian from edited details and return its name."""
+    name = guardian_data.get("guardian")
+    mobile = (guardian_data.get("mobile_number") or "").strip()
+    if mobile and not mobile.startswith("+251"):
+        mobile = f"+251{mobile}"
+
+    if not name and mobile:
+        name = frappe.db.get_value("Guardian", {"mobile_number": mobile}, "name")
+
+    editable = {
+        "guardian_name": guardian_data.get("guardian_name"),
+        "email_address": guardian_data.get("email_address"),
+        "education": guardian_data.get("education"),
+        "occupation": guardian_data.get("occupation"),
+        "work_address": guardian_data.get("work_address"),
+        "image": guardian_data.get("photo") or guardian_data.get("image"),
+    }
+    alt = (guardian_data.get("alternate_number") or "").strip()
+    if alt and not alt.startswith("+251"):
+        alt = f"+251{alt}"
+    if alt:
+        editable["alternate_number"] = alt
+
+    if name and frappe.db.exists("Guardian", name):
+        guardian_doc = frappe.get_doc("Guardian", name)
+        for key, value in editable.items():
+            if value not in (None, ""):
+                setattr(guardian_doc, key, value)
+        if mobile:
+            guardian_doc.mobile_number = mobile
+        guardian_doc.save(ignore_permissions=True)
+        return guardian_doc.name
+
+    guardian_doc = frappe.new_doc("Guardian")
+    guardian_doc.guardian_name = editable.get("guardian_name") or "Guardian"
+    guardian_doc.mobile_number = mobile
+    for key, value in editable.items():
+        if value not in (None, ""):
+            setattr(guardian_doc, key, value)
+    guardian_doc.insert(ignore_permissions=True)
+    return guardian_doc.name
+
+
+@frappe.whitelist(allow_guest=True)
+def submit_existing_student_application(application_data):
+    """Existing-student registration: update the Student record + guardians in
+    place, then create a fresh Student Applicant for the promoted grade.
+
+    Guards: the student must exist, be promoted, and not be restricted.
+    """
+    try:
+        if isinstance(application_data, str):
+            application_data = frappe.parse_json(application_data)
+
+        school_id = (application_data.get("custom_school_id") or "").strip()
+        if not school_id:
+            frappe.throw(_("School ID is required for existing students."))
+
+        student_name = frappe.db.get_value("Student", {"custom_school_id": school_id}, "name")
+        if not student_name:
+            frappe.throw(_("No existing student found with School ID {0}.").format(school_id))
+
+        student = frappe.get_doc("Student", student_name)
+
+        # Re-validate promotion + restriction server-side (never trust the client).
+        if student.get("restricted"):
+            frappe.throw(_("This student is restricted and cannot re-apply: {0}")
+                         .format(student.get("reason_for_restriction") or ""))
+        not_promoted = _get_not_promoted_record(school_id)
+        if not_promoted:
+            frappe.throw(_("This student was not promoted and cannot re-apply online."))
+
+        current_program, current_group = _get_student_current_enrollment(student_name)
+        next_program = application_data.get("program") or _compute_next_program(current_program)
+        if not next_program:
+            frappe.throw(_("This student has graduated; no next grade to apply for."))
+
+        # 1) Sync guardians (shared Guardian docs) from edited data.
+        synced_guardians = []
+        for guardian in application_data.get("guardians", []):
+            guardian_name = _sync_guardian(guardian)
+            synced_guardians.append({
+                "guardian": guardian_name,
+                "guardian_name": guardian.get("guardian_name"),
+                "relation": guardian.get("relation"),
+            })
+
+        # 2) Update the Student doc in place with any changed core info.
+        for field in ("first_name", "middle_name", "last_name", "date_of_birth",
+                      "gender", "nationality", "national_id_fin", "student_mobile_number",
+                      "address_line_1", "address_line_2", "kebele", "sub_city",
+                      "city", "state", "country", "pincode"):
+            value = application_data.get(field)
+            if value not in (None, ""):
+                setattr(student, field, value)
+        if application_data.get("image"):
+            student.image = application_data.get("image")
+
+        # Rewrite the student's guardian table to match the edited set.
+        if synced_guardians:
+            student.set("guardians", [])
+            for g in synced_guardians:
+                row = student.append("guardians")
+                row.guardian = g["guardian"]
+                row.guardian_name = g["guardian_name"]
+                if g.get("relation"):
+                    row.relation = g["relation"]
+        student.save(ignore_permissions=True)
+
+        # 3) Create a fresh Student Applicant for the promoted grade.
+        suggested_section = _suggest_section(next_program, gender=student.gender,
+                                             prev_section=current_group)
+        app_doc = frappe.new_doc("Student Applicant")
+        app_doc.first_name = application_data.get("first_name") or student.first_name
+        app_doc.middle_name = application_data.get("middle_name") or student.middle_name
+        app_doc.last_name = application_data.get("last_name") or student.last_name
+        app_doc.program = next_program
+        app_doc.academic_year = application_data.get("academic_year") or "2019 E.C."
+        app_doc.custom_school_id = school_id
+        app_doc.student_email_id = student.student_email_id or application_data.get("student_email_id") or ""
+        app_doc.date_of_birth = application_data.get("date_of_birth") or student.date_of_birth
+        app_doc.gender = application_data.get("gender") or student.gender
+        app_doc.student_mobile_number = (application_data.get("primary_mobile_number")
+                                         or application_data.get("student_mobile_number")
+                                         or student.student_mobile_number)
+        app_doc.national_id_fin = application_data.get("national_id_fin") or student.get("national_id_fin")
+        app_doc.applicant_type = "Existing"
+        app_doc.nationality = application_data.get("nationality") or student.get("nationality") or "Ethiopian"
+        app_doc.branch = _derive_branch(school_id, application_data.get("branch"))
+        app_doc.suggested_student_section = suggested_section
+        app_doc.application_status = "Applied"
+        if application_data.get("image") or student.image:
+            app_doc.image = application_data.get("image") or student.image
+        if application_data.get("birth_certificate_image"):
+            app_doc.birth_certificate_image = application_data.get("birth_certificate_image")
+
+        for field in ("address_line_1", "address_line_2", "kebele", "sub_city",
+                      "city", "state", "country", "pincode"):
+            value = application_data.get(field) or student.get(field)
+            if value not in (None, ""):
+                setattr(app_doc, field, value)
+
+        for g in synced_guardians:
+            row = app_doc.append("guardians")
+            row.guardian = g["guardian"]
+            row.guardian_name = g["guardian_name"]
+            row.relation = g.get("relation")
+
+        app_doc.insert(ignore_permissions=True)
+        frappe.db.commit()
+
+        return {
+            "name": app_doc.name,
+            "custom_school_id": school_id,
+            "branch": app_doc.branch,
+            "program": next_program,
+            "suggested_section": suggested_section,
+        }
+    except Exception as e:
+        frappe.db.rollback()
+        frappe.log_error(frappe.get_traceback(), "Existing Student Application Error")
+        frappe.throw(_("Error submitting existing-student application: {0}").format(str(e)))
+
+
+# ================================================================
+# STAFF DASHBOARDS: generated IDs + paid applicants
+# ================================================================
+
+def _require_staff():
+    """Allow only registrar/academic/accounts staff to read the dashboards."""
+    allowed = {"System Manager", "Academics User", "Education Manager",
+               "DD Student Registrar", "Accounts Manager", "Accounts User"}
+    if frappe.session.user == "Administrator":
+        return
+    if not (allowed & set(frappe.get_roles())):
+        frappe.throw(_("You are not permitted to view this page."), frappe.PermissionError)
+
+
+@frappe.whitelist()
+def get_generated_ids(search=None, branch=None, applicant_type=None, limit=200):
+    """Staff view: applicants with their generated School ID and status."""
+    _require_staff()
+    filters = {}
+    if branch:
+        filters["branch"] = branch
+    if applicant_type:
+        filters["applicant_type"] = applicant_type
+
+    or_filters = None
+    if search:
+        search = f"%{search}%"
+        or_filters = {
+            "custom_school_id": ["like", search],
+            "first_name": ["like", search],
+            "middle_name": ["like", search],
+            "last_name": ["like", search],
+            "student_mobile_number": ["like", search],
+        }
+
+    rows = frappe.get_all(
+        "Student Applicant",
+        filters=filters,
+        or_filters=or_filters,
+        fields=["name", "first_name", "middle_name", "last_name", "custom_school_id",
+                "program", "branch", "applicant_type", "application_status", "paid",
+                "gender", "student_mobile_number", "suggested_student_section",
+                "academic_year", "creation"],
+        order_by="creation desc",
+        limit_page_length=cint(limit) or 200,
+    )
+    for r in rows:
+        r["full_name"] = " ".join([p for p in [r.get("first_name"), r.get("middle_name"),
+                                                r.get("last_name")] if p])
+    return rows
+
+
+@frappe.whitelist()
+def get_paid_applicants(search=None, branch=None, limit=200):
+    """Staff view: applicants who have applied AND have paid=1."""
+    _require_staff()
+    filters = {"paid": 1}
+    if branch:
+        filters["branch"] = branch
+
+    or_filters = None
+    if search:
+        search = f"%{search}%"
+        or_filters = {
+            "custom_school_id": ["like", search],
+            "first_name": ["like", search],
+            "last_name": ["like", search],
+            "student_mobile_number": ["like", search],
+        }
+
+    rows = frappe.get_all(
+        "Student Applicant",
+        filters=filters,
+        or_filters=or_filters,
+        fields=["name", "first_name", "middle_name", "last_name", "custom_school_id",
+                "program", "branch", "applicant_type", "application_status", "paid",
+                "gender", "student_mobile_number", "suggested_student_section",
+                "academic_year", "creation"],
+        order_by="creation desc",
+        limit_page_length=cint(limit) or 200,
+    )
+    for r in rows:
+        r["full_name"] = " ".join([p for p in [r.get("first_name"), r.get("middle_name"),
+                                                r.get("last_name")] if p])
+    return rows
+
+
+# ================================================================
+# 30-MINUTE ACCOUNTANT NOTIFICATION (CRON)
+# ================================================================
+
+def _applicant_parent_phones(applicant_doc):
+    """Collect the guardian phone numbers for an applicant (';'-joined)."""
+    phones = []
+    for row in applicant_doc.get("guardians", []):
+        mobile = frappe.db.get_value("Guardian", row.guardian, "mobile_number")
+        if mobile and mobile not in phones:
+            phones.append(mobile)
+    return "; ".join(phones)
+
+
+def notify_accountants_of_new_applicants():
+    """Scheduled every 30 minutes.
+
+    Collects Student Applicants created in the last 30 minutes, categorises them
+    by branch and by New/Existing, writes a CSV, and raises an in-system
+    Notification Log (with the CSV attached as a File) for the Accounts roles.
+    """
+    import csv
+    import io
+
+    cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-30)
+    applicants = frappe.get_all(
+        "Student Applicant",
+        filters={"creation": [">=", cutoff]},
+        fields=["name", "first_name", "middle_name", "last_name", "custom_school_id",
+                "gender", "program", "branch", "applicant_type",
+                "suggested_student_section", "student_mobile_number", "creation"],
+        order_by="applicant_type asc, branch asc, creation asc",
+    )
+    if not applicants:
+        return
+
+    # Build the CSV (mandatory columns + branch/type for categorisation).
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([
+        "Applicant Type", "Branch", "Student Name", "School ID", "Gender",
+        "Parent Phone", "Grade (Program)", "Section (Suggested Student Group)",
+        "Student Mobile", "Registered At",
+    ])
+
+    counts = {}
+    for row in applicants:
+        app_doc = frappe.get_doc("Student Applicant", row.name)
+        full_name = " ".join([p for p in [row.first_name, row.middle_name, row.last_name] if p])
+        parent_phones = _applicant_parent_phones(app_doc)
+        atype = row.applicant_type or "New"
+        branch = row.branch or "Main"
+        counts.setdefault(atype, {}).setdefault(branch, 0)
+        counts[atype][branch] += 1
+        writer.writerow([
+            atype, branch, full_name, row.custom_school_id or "", row.gender or "",
+            parent_phones, row.program or "", row.suggested_student_section or "",
+            row.student_mobile_number or "", str(row.creation),
+        ])
+
+    timestamp = frappe.utils.now_datetime().strftime("%Y%m%d_%H%M")
+    file_name = f"new_applicants_{timestamp}.csv"
+    file_doc = frappe.get_doc({
+        "doctype": "File",
+        "file_name": file_name,
+        "is_private": 1,
+        "content": output.getvalue(),
+    })
+    file_doc.insert(ignore_permissions=True)
+
+    # Summary lines for the notification body.
+    summary_lines = []
+    for atype in sorted(counts):
+        for branch in sorted(counts[atype]):
+            summary_lines.append(f"{atype} / {branch}: {counts[atype][branch]}")
+    summary_html = "<br>".join(summary_lines)
+
+    content = (
+        f"<p><b>{len(applicants)}</b> new student applicant(s) were registered "
+        f"in the last 30 minutes.</p>"
+        f"<p>{summary_html}</p>"
+        f"<p><a href='{file_doc.file_url}'>Download CSV: {file_name}</a></p>"
+    )
+
+    # Notify every user holding an Accounts role.
+    recipients = frappe.get_all(
+        "Has Role",
+        filters={"role": ["in", ACCOUNTS_NOTIFY_ROLES], "parenttype": "User"},
+        distinct=True,
+        pluck="parent",
+    )
+    for user in set(recipients):
+        if user in ("Administrator", "Guest") or not frappe.db.get_value("User", user, "enabled"):
+            continue
+        frappe.get_doc({
+            "doctype": "Notification Log",
+            "subject": f"{len(applicants)} new applicant(s) - last 30 min",
+            "email_content": content,
+            "for_user": user,
+            "type": "Alert",
+            "document_type": "File",
+            "document_name": file_doc.name,
+        }).insert(ignore_permissions=True)
+
+    frappe.db.commit()

--- a/education/education/api.py
+++ b/education/education/api.py
@@ -3171,7 +3171,7 @@ def generate_student_report_cards(academic_year, student=None, student_group=Non
 # Roles that receive the 30-minute "new applicants" notification. There is no
 # role literally named "Accountant" on the site, so we target both Accounts
 # roles. Edit this list to change who gets notified - it is pure data.
-ACCOUNTS_NOTIFY_ROLES = ["Accounts Manager", "Accounts User"]
+ACCOUNTS_NOTIFY_ROLES = ["Accountant", "Accounts Manager", "Accounts User"]
 
 
 def _derive_branch(school_id=None, explicit=None):

--- a/education/education/doctype/not_promoted_student/not_promoted_student.json
+++ b/education/education/doctype/not_promoted_student/not_promoted_student.json
@@ -1,0 +1,124 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:NPS-{#####}",
+ "creation": "2026-07-24 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "school_id",
+  "student",
+  "student_name",
+  "column_break_main",
+  "academic_year",
+  "current_program",
+  "section_break_reason",
+  "reason"
+ ],
+ "fields": [
+  {
+   "fieldname": "school_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "School ID",
+   "reqd": 1,
+   "description": "School ID of the student who was NOT promoted (e.g. M1/12345/19, M2/12345/19 or MB/DD/12345/19)."
+  },
+  {
+   "fieldname": "student",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Student",
+   "options": "Student",
+   "description": "Optional link to the Student record. Lookup is primarily by School ID."
+  },
+  {
+   "fetch_from": "student.student_name",
+   "fieldname": "student_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Student Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "academic_year",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Academic Year",
+   "options": "Academic Year",
+   "description": "The academic year in which the student was not promoted."
+  },
+  {
+   "fieldname": "current_program",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Current / Repeat Program",
+   "options": "Program",
+   "description": "The program the student remains in (they repeat this grade instead of advancing)."
+  },
+  {
+   "fieldname": "section_break_reason",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "reason",
+   "fieldtype": "Small Text",
+   "label": "Reason"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-24 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Education",
+ "name": "Not Promoted Student",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Academics User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Education Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "DD Student Registrar",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/education/education/doctype/not_promoted_student/not_promoted_student.py
+++ b/education/education/doctype/not_promoted_student/not_promoted_student.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class NotPromotedStudent(Document):
+	def validate(self):
+		# Normalise the school ID so lookups from the application pages match
+		# regardless of stray whitespace.
+		if self.school_id:
+			self.school_id = self.school_id.strip()
+
+		# If a Student is linked but the school ID is empty, backfill it.
+		if self.student and not self.school_id:
+			self.school_id = frappe.db.get_value("Student", self.student, "custom_school_id")

--- a/education/fixtures/custom_field.json
+++ b/education/fixtures/custom_field.json
@@ -1,0 +1,29 @@
+[
+ {
+  "doctype": "Custom Field",
+  "name": "Student Applicant-branch",
+  "dt": "Student Applicant",
+  "fieldname": "branch",
+  "label": "Branch",
+  "fieldtype": "Select",
+  "options": "Main\nMBS #2\nMBS Dembi Dollo",
+  "default": "Main",
+  "insert_after": "custom_school_id",
+  "in_list_view": 1,
+  "in_standard_filter": 1,
+  "translatable": 0,
+  "description": "School branch this applicant belongs to. Auto-assigned from the registration page and School ID prefix (MB/DD -> MBS Dembi Dollo, M2 -> MBS #2, otherwise Main)."
+ },
+ {
+  "doctype": "Custom Field",
+  "name": "Student Applicant-suggested_student_section",
+  "dt": "Student Applicant",
+  "fieldname": "suggested_student_section",
+  "label": "Suggested Student Section",
+  "fieldtype": "Data",
+  "insert_after": "branch",
+  "read_only": 1,
+  "translatable": 0,
+  "description": "System-suggested Student Group for this applicant (gender-balanced round-robin for new applicants; carried forward from the previous section for existing students). A human still does the final enrollment."
+ }
+]

--- a/education/hooks.py
+++ b/education/hooks.py
@@ -242,6 +242,33 @@ after_install = "education.install.after_install"
 # 	],
 # }
 
+# Every 30 minutes: notify Accounts users of newly registered applicants,
+# split by branch and by New/Existing, with a downloadable CSV attached.
+scheduler_events = {
+	"cron": {
+		"*/30 * * * *": [
+			"education.education.api.notify_accountants_of_new_applicants"
+		]
+	}
+}
+
+# Fixtures - custom fields added to core doctypes so they travel with the app.
+fixtures = [
+	{
+		"dt": "Custom Field",
+		"filters": [
+			[
+				"name",
+				"in",
+				[
+					"Student Applicant-branch",
+					"Student Applicant-suggested_student_section"
+				]
+			]
+		]
+	}
+]
+
 # Testing
 # -------
 

--- a/education/www/apply_dd.html
+++ b/education/www/apply_dd.html
@@ -130,12 +130,12 @@
                         <div class="flex items-center">
                             <h1 class="text-2xl font-bold text-gray-900">MBS Dembi Dollo Student Registration Page</h1>
                         </div>
-                        <div class="flex items-center space-x-4">
+                        <div v-if="currentStep >= 1" class="flex items-center space-x-4">
                             <div class="text-sm text-gray-500">
                                 Step {{ currentStep }} of {{ totalSteps }}
                             </div>
                             <div class="w-48 bg-gray-200 rounded-full h-2">
-                                <div 
+                                <div
                                     class="bg-blue-600 h-2 rounded-full step-indicator"
                                     :style="{ width: `${(currentStep / totalSteps) * 100}%` }"
                                 ></div>
@@ -148,7 +148,119 @@
             <!-- Main Content -->
             <main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
                 <div class="bg-white rounded-lg form-card p-6">
-                    
+
+                    <!-- Step 0: Start Gate - New vs Existing Student -->
+                    <div v-if="currentStep === 0" class="space-y-6">
+                        <div class="text-center">
+                            <h2 class="text-2xl font-semibold text-gray-900 mb-2">Welcome</h2>
+                            <p class="text-gray-600">Are you registering a new student or an existing student?</p>
+                        </div>
+
+                        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <button
+                                @click="chooseFlow('new')"
+                                :class="[
+                                    'rounded-lg border p-8 text-center transition-all duration-200',
+                                    flowChoice === 'new' ? 'border-blue-500 bg-blue-50 text-blue-900' : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
+                                ]"
+                            >
+                                <svg class="h-10 w-10 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                </svg>
+                                <p class="text-lg font-medium">New Student</p>
+                                <p class="text-sm text-gray-500">First time applying (School ID auto-generated)</p>
+                            </button>
+
+                            <button
+                                @click="chooseFlow('existing')"
+                                :class="[
+                                    'rounded-lg border p-8 text-center transition-all duration-200',
+                                    flowChoice === 'existing' ? 'border-blue-500 bg-blue-50 text-blue-900' : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
+                                ]"
+                            >
+                                <svg class="h-10 w-10 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                                </svg>
+                                <p class="text-lg font-medium">Existing Student</p>
+                                <p class="text-sm text-gray-500">Already has a school ID</p>
+                            </button>
+                        </div>
+
+                        <!-- New Student: continue -->
+                        <div v-if="flowChoice === 'new'" class="border-t border-gray-200 pt-6">
+                            <div class="bg-blue-50 p-4 rounded-lg mb-4">
+                                <p class="text-sm text-blue-800">A new School ID will be generated automatically in the format <strong>MB/DD/#####/19</strong> on submission.</p>
+                            </div>
+                            <button @click="startNewFlow" class="btn-primary w-full">Continue as New Student →</button>
+                        </div>
+
+                        <!-- Existing Student: school ID lookup + rich detail -->
+                        <div v-if="flowChoice === 'existing'" class="space-y-4 border-t border-gray-200 pt-6">
+                            <label class="block text-sm font-medium text-gray-700">Enter the student's School ID</label>
+                            <div class="flex space-x-2">
+                                <input
+                                    v-model="existingSchoolId"
+                                    type="text"
+                                    class="input-field flex-1"
+                                    placeholder="e.g., MB/DD/12345/19"
+                                    :disabled="isLoadingExistingDetails"
+                                    @keydown.enter="lookupExistingStudent"
+                                >
+                                <button
+                                    @click="lookupExistingStudent"
+                                    :disabled="isLoadingExistingDetails || !existingSchoolId.trim()"
+                                    :class="[
+                                        'px-4 py-2 rounded-md font-medium transition-colors',
+                                        isLoadingExistingDetails || !existingSchoolId.trim() ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-blue-600 text-white hover:bg-blue-700'
+                                    ]"
+                                >
+                                    <span v-if="isLoadingExistingDetails">Checking...</span>
+                                    <span v-else>Fetch Details</span>
+                                </button>
+                            </div>
+                            <div v-if="schoolIdError" class="text-red-600 text-sm" v-text="schoolIdError"></div>
+
+                            <div v-if="existingDetails && existingDetails.found" class="rounded-lg border border-gray-200 overflow-hidden">
+                                <div class="bg-gray-50 p-5 flex items-start space-x-4">
+                                    <img v-if="existingDetails.image" :src="existingDetails.image" alt="Student" class="h-24 w-24 rounded-lg object-cover border border-gray-300">
+                                    <div v-else class="h-24 w-24 rounded-lg bg-gray-200 flex items-center justify-center text-gray-400 text-xs">No Photo</div>
+                                    <div class="flex-1">
+                                        <h3 class="text-lg font-semibold text-gray-900" v-text="existingDetails.student_name"></h3>
+                                        <p class="text-sm text-gray-600">School ID: <strong v-text="existingDetails.custom_school_id"></strong></p>
+                                        <p class="text-sm text-gray-600">Phone: <span v-text="existingDetails.student_mobile_number || '—'"></span></p>
+                                        <p class="text-sm text-gray-600">Current Grade: <span v-text="existingDetails.current_program || '—'"></span></p>
+                                        <p class="text-sm text-gray-600">Branch: <span v-text="existingDetails.branch"></span></p>
+                                    </div>
+                                </div>
+                                <div class="p-5 space-y-3">
+                                    <div v-if="existingDetails.is_restricted" class="bg-red-50 border-l-4 border-red-500 p-3 text-sm text-red-800">
+                                        <strong>Restricted:</strong> <span v-text="existingDetails.block_reason"></span>
+                                    </div>
+                                    <div v-else-if="!existingDetails.is_promoted" class="bg-yellow-50 border-l-4 border-yellow-500 p-3 text-sm text-yellow-800">
+                                        <strong>Not Promoted:</strong> <span v-text="existingDetails.block_reason"></span>
+                                    </div>
+                                    <div v-else class="bg-green-50 border-l-4 border-green-500 p-3 text-sm text-green-800">
+                                        <strong>Promoted.</strong> This student will be registered for <strong v-text="existingDetails.next_program"></strong>.
+                                        <span v-if="existingDetails.suggested_section">Suggested section: <strong v-text="existingDetails.suggested_section"></strong>.</span>
+                                    </div>
+                                    <div v-if="existingDetails.guardians && existingDetails.guardians.length" class="text-sm text-gray-700">
+                                        <p class="font-medium mb-1">Parent / Guardian(s) on record:</p>
+                                        <ul class="list-disc ml-5">
+                                            <li v-for="g in existingDetails.guardians" :key="g.guardian">
+                                                <span v-text="g.guardian_name"></span>
+                                                <span class="text-gray-500" v-text="g.relation ? '(' + g.relation + ')' : ''"></span>
+                                                — <span v-text="g.mobile_number"></span>
+                                            </li>
+                                        </ul>
+                                        <p class="text-xs text-gray-500 mt-1">You'll be able to review and edit parent details in the next steps.</p>
+                                    </div>
+                                    <button v-if="existingDetails.can_continue" @click="startExistingFlow" class="btn-primary w-full">Continue Application →</button>
+                                    <p v-else class="text-sm text-red-600 text-center">This student cannot re-apply online. Please contact the school office.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Step 1: Guardian Information -->
                     <div v-if="currentStep === 1" class="space-y-6">
                         <div class="text-center">
@@ -415,87 +527,26 @@
                         </div>
                     </div>
                     
-                    <!-- Step 3: Student Type Selection -->
+                    <!-- Step 3: Confirm (type chosen on the start page) -->
                     <div v-if="currentStep === 3" class="space-y-6">
                         <div class="text-center">
-                            <h2 class="text-xl font-semibold text-gray-900 mb-4">Student Type</h2>
-                            <p class="text-gray-600">Is this a new student or an existing student?</p>
+                            <h2 class="text-xl font-semibold text-gray-900 mb-4">Confirm</h2>
+                            <p class="text-gray-600">Review your selection before continuing.</p>
                         </div>
-                        
-                        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                            <button
-                                @click="studentType = 'new'"
-                                :class="[
-                                    'relative rounded-lg border p-6 text-left transition-all duration-200',
-                                    studentType === 'new' 
-                                        ? 'border-blue-500 bg-blue-50 text-blue-900' 
-                                        : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
-                                ]"
-                            >
-                                <div class="flex items-center">
-                                    <div class="flex-shrink-0">
-                                        <svg class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                                        </svg>
-                                    </div>
-                                    <div class="ml-4">
-                                        <p class="text-lg font-medium">New Student</p>
-                                        <p class="text-sm text-gray-500">First time applying to our school</p>
-                                    </div>
-                                </div>
-                            </button>
-                            
-                            <button
-                                @click="studentType = 'existing'"
-                                :class="[
-                                    'relative rounded-lg border p-6 text-left transition-all duration-200',
-                                    studentType === 'existing' 
-                                        ? 'border-blue-500 bg-blue-50 text-blue-900' 
-                                        : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
-                                ]"
-                            >
-                                <div class="flex items-center">
-                                    <div class="flex-shrink-0">
-                                        <svg class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                        </svg>
-                                    </div>
-                                    <div class="ml-4">
-                                        <p class="text-lg font-medium">Existing Student</p>
-                                        <p class="text-sm text-gray-500">Already has a school ID</p>
-                                    </div>
-                                </div>
-                            </button>
+                        <div class="bg-gray-50 p-6 rounded-lg space-y-2 text-sm text-gray-800">
+                            <p><strong>Registration Type:</strong> <span v-text="studentType === 'existing' ? 'Existing Student' : 'New Student'"></span></p>
+                            <p><strong>Branch:</strong> MBS Dembi Dollo</p>
+                            <template v-if="studentType === 'new'">
+                                <p class="text-gray-600">A new School ID (MB/DD/#####/19) will be generated on submission.</p>
+                            </template>
+                            <template v-if="studentType === 'existing' && existingDetails">
+                                <p><strong>Student:</strong> <span v-text="existingDetails.student_name"></span></p>
+                                <p><strong>School ID:</strong> <span v-text="existingDetails.custom_school_id"></span></p>
+                                <p><strong>Applying For:</strong> <span v-text="existingDetails.next_program"></span> <span class="text-gray-500">(promoted from <span v-text="existingDetails.current_program"></span>)</span></p>
+                                <p v-if="existingDetails.suggested_section"><strong>Suggested Section:</strong> <span v-text="existingDetails.suggested_section"></span></p>
+                            </template>
                         </div>
-                        
-                        <!-- School ID for Existing Students (no lookup; recorded as-is) -->
-                        <div v-if="studentType === 'existing'" class="space-y-4">
-                            <label class="block text-sm font-medium text-gray-700">Enter School ID *</label>
-                            <div class="relative">
-                                <div class="flex">
-                                    <span class="inline-flex items-center px-3 py-2 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 text-sm font-medium">MB/DD/</span>
-                                    <input
-                                        v-model="existingSchoolId"
-                                        type="text"
-                                        class="input-field rounded-l-none"
-                                        placeholder="e.g., 12345"
-                                    >
-                                </div>
-                            </div>
-                            <p class="text-xs text-gray-600">
-                                This student will be recorded as an <strong>existing student</strong>. The School ID will be saved as
-                                <strong v-text="existingSchoolId ? ('MB/DD/' + existingSchoolId.trim()) : 'MB/DD/...'"></strong>.
-                                No lookup is performed &mdash; a new applicant record is created.
-                            </p>
-                        </div>
-
-                        <!-- New Student note (school ID auto-generated) -->
-                        <div v-if="studentType === 'new'" class="bg-blue-50 p-4 rounded-lg">
-                            <p class="text-sm text-blue-800">
-                                A new School ID will be generated automatically in the format
-                                <strong>MB/DD/#####/19</strong> when the application is submitted.
-                            </p>
-                        </div>
+                        <p class="text-xs text-gray-500 text-center">To change this, use "Start New Application".</p>
                     </div>
                     
                     <!-- Step 4: Student Details -->
@@ -682,6 +733,7 @@
                                 <div>
                                     <p><strong>Mobile:</strong> <span v-text="studentData.primary_mobile_number"></span></p>
                                     <p><strong>Program:</strong> <span v-text="selectedProgramName"></span></p>
+                                    <p v-if="studentData.custom_school_id"><strong>School ID:</strong> <span class="font-semibold text-blue-700" v-text="studentData.custom_school_id"></span></p>
                                     <p v-if="isNurseryGrade && studentData.birth_certificate_image"><strong>Birth Certificate:</strong> ✓ Uploaded</p>
                                 </div>
                             </div>
@@ -797,6 +849,11 @@
                         </svg>
                     </div>
                     <h3 class="text-lg leading-6 font-medium text-gray-900 mt-2">Application Submitted Successfully!</h3>
+                    <div v-if="generatedSchoolId" class="mx-6 mt-3 mb-1 rounded-lg bg-blue-50 border border-blue-200 py-3">
+                        <p class="text-xs uppercase tracking-wide text-blue-500">Generated Student ID</p>
+                        <p class="text-2xl font-bold text-blue-800" v-text="generatedSchoolId"></p>
+                        <p v-if="submittedBranch" class="text-xs text-blue-600 mt-1">Branch: <span v-text="submittedBranch"></span></p>
+                    </div>
                     <div class="mt-2 px-7 py-3">
                         <p class="text-sm text-gray-500">
                             Your application has been submitted with ID: <strong v-text="submittedApplicationId"></strong>
@@ -855,13 +912,20 @@
         createApp({
             data() {
                 return {
-                    currentStep: 1,
+                    currentStep: 0,
                     totalSteps: 5,
                     loading: true,
                     isSubmitting: false,
                     guardianType: 'parent',
                     studentType: 'new',
                     existingSchoolId: '',
+                    schoolIdError: '',
+                    flowChoice: '',
+                    existingDetails: null,
+                    isLoadingExistingDetails: false,
+                    generatedSchoolId: '',
+                    submittedBranch: '',
+                    existingStudent: null,
                     showSuccessModal: false,
                     submittedApplicationId: '',
                     fatherData: {
@@ -1052,13 +1116,8 @@
                                 this.studentData.address_line_1 &&
                                 this.studentData.kebele
                             );
-                        case 3: // Student Type Selection
-                            if (this.studentType === 'new') {
-                                return true;
-                            } else if (this.studentType === 'existing') {
-                                return !!this.existingSchoolId.trim();
-                            }
-                            return false;
+                        case 3: // Confirm (type chosen on the start gate)
+                            return true;
                         case 4: // Student Details
                             const dateValid = this.calendarType === 'ethiopian' ?
                                 (this.ethiopianDate && !this.ethiopianDateError) :
@@ -1232,7 +1291,129 @@
                         this.currentStep--;
                     }
                 },
-                
+
+                // --- Start gate (New vs Existing) ---
+                chooseFlow(choice) {
+                    this.flowChoice = choice;
+                    this.studentType = choice;
+                    if (choice === 'new') {
+                        this.existingDetails = null;
+                        this.existingStudent = null;
+                        this.schoolIdError = '';
+                    }
+                },
+
+                startNewFlow() {
+                    this.studentType = 'new';
+                    this.currentStep = 1;
+                },
+
+                async lookupExistingStudent() {
+                    const schoolId = (this.existingSchoolId || '').trim();
+                    if (!schoolId) return;
+                    this.isLoadingExistingDetails = true;
+                    this.schoolIdError = '';
+                    this.existingDetails = null;
+                    try {
+                        const response = await fetch('/api/method/education.education.api.get_existing_student_details', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ school_id: schoolId })
+                        });
+                        const data = await response.json();
+                        const details = data.message;
+                        if (!details || !details.found) {
+                            this.schoolIdError = (details && details.message) || 'No existing student found with this School ID.';
+                            return;
+                        }
+                        this.existingDetails = details;
+                    } catch (error) {
+                        console.error('Existing student lookup failed:', error);
+                        this.schoolIdError = 'Could not look up the student. Please try again.';
+                    } finally {
+                        this.isLoadingExistingDetails = false;
+                    }
+                },
+
+                startExistingFlow() {
+                    const d = this.existingDetails;
+                    if (!d || !d.can_continue) return;
+                    this.studentType = 'existing';
+                    this.studentData.first_name = d.first_name || '';
+                    this.studentData.middle_name = d.middle_name || '';
+                    this.studentData.last_name = d.last_name || '';
+                    this.studentData.gender = d.gender || '';
+                    this.studentData.date_of_birth = d.date_of_birth || '';
+                    this.studentData.primary_mobile_number = d.student_mobile_number || '';
+                    this.studentData.program = d.next_program || '';
+                    this.studentData.custom_school_id = d.custom_school_id || '';
+                    this.studentData.image = d.image || '';
+                    this.studentData.address_line_1 = d.address_line_1 || '';
+                    this.studentData.sub_city = d.sub_city || '';
+                    this.studentData.kebele = d.kebele || '';
+                    if (d.date_of_birth && this.hasOwnProperty('calendarType')) {
+                        this.calendarType = 'gregorian';
+                    }
+                    this.prefillGuardiansFromExisting(d.guardians || []);
+                    this.existingStudent = {
+                        custom_school_id: d.custom_school_id,
+                        first_name: d.first_name,
+                        middle_name: d.middle_name,
+                        last_name: d.last_name
+                    };
+                    this.currentStep = 1;
+                },
+
+                prefillGuardiansFromExisting(guardians) {
+                    const findByRelation = (rel) => guardians.find(g => (g.relation || '').toLowerCase() === rel);
+                    const father = findByRelation('father');
+                    const mother = findByRelation('mother');
+                    if (father || mother) {
+                        this.guardianType = 'parent';
+                        if (father) this.assignGuardian(this.fatherData, father);
+                        if (mother) this.assignGuardian(this.motherData, mother);
+                    } else if (guardians.length) {
+                        this.guardianType = 'guardian';
+                        this.assignGuardian(this.guardianData, guardians[0]);
+                        this.guardianData.relation = guardians[0].relation || 'Other';
+                    }
+                },
+
+                assignGuardian(target, g) {
+                    target.guardian = g.guardian || '';
+                    target.guardian_name = g.guardian_name || '';
+                    target.mobile_number = (g.mobile_number || '').replace('+251', '');
+                    target.alternate_number = (g.alternate_number || '').replace('+251', '');
+                    target.email_address = g.email_address || '';
+                    target.education = g.education || '';
+                    target.occupation = g.occupation || '';
+                    target.work_address = g.work_address || '';
+                    target.image = g.image || '';
+                },
+
+                buildDetailedGuardians() {
+                    const pack = (data, relation) => ({
+                        guardian: data.guardian || '',
+                        guardian_name: data.guardian_name || '',
+                        relation: relation,
+                        mobile_number: data.mobile_number || '',
+                        alternate_number: data.alternate_number || '',
+                        email_address: data.email_address || '',
+                        education: data.education === 'Other' ? (data.education_other || 'Other') : (data.education || ''),
+                        occupation: data.occupation === 'Other' ? (data.occupation_other || 'Other') : (data.occupation || ''),
+                        work_address: data.work_address || '',
+                        image: data.image || ''
+                    });
+                    const out = [];
+                    if (this.guardianType === 'parent') {
+                        if (this.fatherData.guardian_name) out.push(pack(this.fatherData, 'Father'));
+                        if (this.motherData.guardian_name) out.push(pack(this.motherData, 'Mother'));
+                    } else {
+                        if (this.guardianData.guardian_name) out.push(pack(this.guardianData, this.guardianData.relation || 'Other'));
+                    }
+                    return out;
+                },
+
                 async submitApplication() {
                     // Validate the form first
                     if (!this.validateForm()) {
@@ -1381,13 +1562,8 @@
                                 throw new Error(`Failed to get school ID: ${schoolIdData.exc || 'Unknown error'}`);
                             }
                         } else if (this.studentType === 'existing') {
-                            // No lookup: record as a new applicant flagged "Existing",
-                            // prefixing the entered ID with MB/DD/.
-                            schoolId = 'MB/DD/' + this.existingSchoolId.trim();
-                            // Derive a unique student email from the school ID so the
-                            // unique student_email_id constraint is never violated by
-                            // multiple blank emails.
-                            studentEmailId = schoolId.replace(/[\\/]/g, '').toLowerCase() + '@m.b.s';
+                            // Use the canonical School ID fetched from the Student record.
+                            schoolId = (this.existingDetails && this.existingDetails.custom_school_id) || this.existingSchoolId.trim();
                         }
 
                         // Prepare application data
@@ -1396,36 +1572,65 @@
                             custom_school_id: schoolId,
                             student_email_id: studentEmailId,
                             applicant_type: this.studentType === 'existing' ? 'Existing' : 'New',
+                            branch: 'MBS Dembi Dollo',
                             birth_certificate_image: this.studentData.birth_certificate_image,
                             guardians: guardians,
                             siblings: []
                         };
-                        
-                        // Create application
-                        const applicationResponse = await fetch('/api/method/education.education.api.create_student_application', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({
-                                application_data: applicationData
-                            })
-                        });
-                        
-                        if (!applicationResponse.ok) {
-                            const errorData = await applicationResponse.json();
-                            throw new Error(`Failed to create application: ${errorData.message || errorData.exc || applicationResponse.statusText}`);
-                        }
-                        
-                        const applicationResult = await applicationResponse.json();
-                        
-                        if (applicationResult.message) {
-                            this.submittedApplicationId = applicationResult.message;
-                            this.showSuccessModal = true;
+
+                        if (this.studentType === 'existing') {
+                            // Existing student: sync the Student record + guardians, then
+                            // create a fresh applicant for the promoted grade.
+                            applicationData.program = (this.existingDetails && this.existingDetails.next_program) || this.studentData.program;
+                            applicationData.guardians = this.buildDetailedGuardians();
+                            const existingResponse = await fetch('/api/method/education.education.api.submit_existing_student_application', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ application_data: applicationData })
+                            });
+                            if (!existingResponse.ok) {
+                                const errorData = await existingResponse.json();
+                                throw new Error(`Failed to submit application: ${errorData.message || errorData.exc || existingResponse.statusText}`);
+                            }
+                            const existingResult = await existingResponse.json();
+                            const payload = existingResult.message;
+                            if (payload && payload.name) {
+                                this.submittedApplicationId = payload.name;
+                                this.generatedSchoolId = payload.custom_school_id || schoolId;
+                                this.submittedBranch = payload.branch || 'MBS Dembi Dollo';
+                                this.showSuccessModal = true;
+                            } else {
+                                throw new Error(`Failed to submit application: ${existingResult.exc || 'Unknown error'}`);
+                            }
                         } else {
-                            throw new Error(`Failed to create application: ${applicationResult.exc || 'Unknown error'}`);
+                            // Create application (new student)
+                            const applicationResponse = await fetch('/api/method/education.education.api.create_student_application', {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                },
+                                body: JSON.stringify({
+                                    application_data: applicationData
+                                })
+                            });
+
+                            if (!applicationResponse.ok) {
+                                const errorData = await applicationResponse.json();
+                                throw new Error(`Failed to create application: ${errorData.message || errorData.exc || applicationResponse.statusText}`);
+                            }
+
+                            const applicationResult = await applicationResponse.json();
+
+                            if (applicationResult.message) {
+                                this.submittedApplicationId = applicationResult.message;
+                                this.generatedSchoolId = schoolId;
+                                this.submittedBranch = 'MBS Dembi Dollo';
+                                this.showSuccessModal = true;
+                            } else {
+                                throw new Error(`Failed to create application: ${applicationResult.exc || 'Unknown error'}`);
+                            }
                         }
-                        
+
                     } catch (error) {
                         console.error('Error submitting application:', error);
                         
@@ -1667,12 +1872,18 @@
                 
                 resetForm() {
                     this.showSuccessModal = false;
-                    this.currentStep = 1;
+                    this.currentStep = 0;
+                    this.flowChoice = '';
                     this.guardianType = 'parent';
                     this.studentType = 'new';
                     this.existingSchoolId = '';
+                    this.schoolIdError = '';
+                    this.existingDetails = null;
+                    this.existingStudent = null;
+                    this.generatedSchoolId = '';
+                    this.submittedBranch = '';
                     this.submittedApplicationId = '';
-                    
+
                     // Reset all form data
                     this.fatherData = {
                         guardian_name: '',
@@ -1763,7 +1974,11 @@
                 addAnotherChild() {
                     // Preserve guardian and address information, only reset student details
                     this.showSuccessModal = false;
-                    this.currentStep = 3; // Start from student type selection step (now step 3)
+                    this.currentStep = 0; // Back to the New/Existing start gate
+                    this.flowChoice = '';
+                    this.existingDetails = null;
+                    this.generatedSchoolId = '';
+                    this.submittedBranch = '';
                     this.submittedApplicationId = '';
                     
                     // Keep guardian type and data intact (don't reset guardian info)

--- a/education/www/mbreg1825.html
+++ b/education/www/mbreg1825.html
@@ -130,12 +130,12 @@
                         <div class="flex items-center">
                             <h1 class="text-2xl font-bold text-gray-900">Member Registration 1825</h1>
                         </div>
-                        <div class="flex items-center space-x-4">
+                        <div v-if="currentStep >= 1" class="flex items-center space-x-4">
                             <div class="text-sm text-gray-500">
                                 Step {{ currentStep }} of {{ totalSteps }}
                             </div>
                             <div class="w-48 bg-gray-200 rounded-full h-2">
-                                <div 
+                                <div
                                     class="bg-blue-600 h-2 rounded-full step-indicator"
                                     :style="{ width: `${(currentStep / totalSteps) * 100}%` }"
                                 ></div>
@@ -148,7 +148,158 @@
             <!-- Main Content -->
             <main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
                 <div class="bg-white rounded-lg form-card p-6">
-                    
+
+                    <!-- Step 0: Start Gate - New vs Existing Student -->
+                    <div v-if="currentStep === 0" class="space-y-6">
+                        <div class="text-center">
+                            <h2 class="text-2xl font-semibold text-gray-900 mb-2">Welcome</h2>
+                            <p class="text-gray-600">Are you registering a new student or an existing student?</p>
+                        </div>
+
+                        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <button
+                                @click="chooseFlow('new')"
+                                :class="[
+                                    'rounded-lg border p-8 text-center transition-all duration-200',
+                                    flowChoice === 'new'
+                                        ? 'border-blue-500 bg-blue-50 text-blue-900'
+                                        : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
+                                ]"
+                            >
+                                <svg class="h-10 w-10 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                </svg>
+                                <p class="text-lg font-medium">New Student</p>
+                                <p class="text-sm text-gray-500">First time applying to our school</p>
+                            </button>
+
+                            <button
+                                @click="chooseFlow('existing')"
+                                :class="[
+                                    'rounded-lg border p-8 text-center transition-all duration-200',
+                                    flowChoice === 'existing'
+                                        ? 'border-blue-500 bg-blue-50 text-blue-900'
+                                        : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
+                                ]"
+                            >
+                                <svg class="h-10 w-10 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                                </svg>
+                                <p class="text-lg font-medium">Existing Student</p>
+                                <p class="text-sm text-gray-500">Already has a school ID</p>
+                            </button>
+                        </div>
+
+                        <!-- New Student: branch selection + continue -->
+                        <div v-if="flowChoice === 'new'" class="space-y-4 border-t border-gray-200 pt-6">
+                            <label class="block text-sm font-medium text-gray-700">Select Branch</label>
+                            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                <button
+                                    @click="branchSelection = 'M1'"
+                                    :class="[
+                                        'rounded-lg border p-4 text-left transition-all duration-200',
+                                        branchSelection === 'M1' ? 'border-blue-500 bg-blue-50 text-blue-900' : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
+                                    ]"
+                                >
+                                    <span class="font-semibold text-blue-600 mr-2">M1</span> Main Branch
+                                </button>
+                                <button
+                                    @click="branchSelection = 'M2'"
+                                    :class="[
+                                        'rounded-lg border p-4 text-left transition-all duration-200',
+                                        branchSelection === 'M2' ? 'border-blue-500 bg-blue-50 text-blue-900' : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
+                                    ]"
+                                >
+                                    <span class="font-semibold text-green-600 mr-2">M2</span> Second Branch (MBS #2)
+                                </button>
+                            </div>
+                            <button @click="startNewFlow" :disabled="!branchSelection" class="btn-primary w-full" :class="{ 'opacity-50 cursor-not-allowed': !branchSelection }">
+                                Continue as New Student →
+                            </button>
+                        </div>
+
+                        <!-- Existing Student: school ID lookup + rich detail -->
+                        <div v-if="flowChoice === 'existing'" class="space-y-4 border-t border-gray-200 pt-6">
+                            <label class="block text-sm font-medium text-gray-700">Enter the student's School ID</label>
+                            <div class="flex space-x-2">
+                                <input
+                                    v-model="existingSchoolId"
+                                    type="text"
+                                    class="input-field flex-1"
+                                    placeholder="e.g., M1/10001/19"
+                                    :disabled="isLoadingExistingDetails"
+                                    @keydown.enter="lookupExistingStudent"
+                                >
+                                <button
+                                    @click="lookupExistingStudent"
+                                    :disabled="isLoadingExistingDetails || !existingSchoolId.trim()"
+                                    :class="[
+                                        'px-4 py-2 rounded-md font-medium transition-colors',
+                                        isLoadingExistingDetails || !existingSchoolId.trim() ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-blue-600 text-white hover:bg-blue-700'
+                                    ]"
+                                >
+                                    <span v-if="isLoadingExistingDetails">Checking...</span>
+                                    <span v-else>Fetch Details</span>
+                                </button>
+                            </div>
+                            <div v-if="schoolIdError" class="text-red-600 text-sm" v-text="schoolIdError"></div>
+
+                            <!-- Rich detail card -->
+                            <div v-if="existingDetails && existingDetails.found" class="rounded-lg border border-gray-200 overflow-hidden">
+                                <div class="bg-gray-50 p-5 flex items-start space-x-4">
+                                    <img v-if="existingDetails.image" :src="existingDetails.image" alt="Student" class="h-24 w-24 rounded-lg object-cover border border-gray-300">
+                                    <div v-else class="h-24 w-24 rounded-lg bg-gray-200 flex items-center justify-center text-gray-400 text-xs">No Photo</div>
+                                    <div class="flex-1">
+                                        <h3 class="text-lg font-semibold text-gray-900" v-text="existingDetails.student_name"></h3>
+                                        <p class="text-sm text-gray-600">School ID: <strong v-text="existingDetails.custom_school_id"></strong></p>
+                                        <p class="text-sm text-gray-600">Phone: <span v-text="existingDetails.student_mobile_number || '—'"></span></p>
+                                        <p class="text-sm text-gray-600">Current Grade: <span v-text="existingDetails.current_program || '—'"></span></p>
+                                        <p class="text-sm text-gray-600">Branch: <span v-text="existingDetails.branch"></span></p>
+                                    </div>
+                                </div>
+
+                                <!-- Promotion / status banner -->
+                                <div class="p-5 space-y-3">
+                                    <div v-if="existingDetails.is_restricted" class="bg-red-50 border-l-4 border-red-500 p-3 text-sm text-red-800">
+                                        <strong>Restricted:</strong> <span v-text="existingDetails.block_reason"></span>
+                                    </div>
+                                    <div v-else-if="!existingDetails.is_promoted" class="bg-yellow-50 border-l-4 border-yellow-500 p-3 text-sm text-yellow-800">
+                                        <strong>Not Promoted:</strong> <span v-text="existingDetails.block_reason"></span>
+                                    </div>
+                                    <div v-else class="bg-green-50 border-l-4 border-green-500 p-3 text-sm text-green-800">
+                                        <strong>Promoted.</strong> This student will be registered for
+                                        <strong v-text="existingDetails.next_program"></strong>.
+                                        <span v-if="existingDetails.suggested_section">Suggested section: <strong v-text="existingDetails.suggested_section"></strong>.</span>
+                                    </div>
+
+                                    <!-- Guardians preview -->
+                                    <div v-if="existingDetails.guardians && existingDetails.guardians.length" class="text-sm text-gray-700">
+                                        <p class="font-medium mb-1">Parent / Guardian(s) on record:</p>
+                                        <ul class="list-disc ml-5">
+                                            <li v-for="g in existingDetails.guardians" :key="g.guardian">
+                                                <span v-text="g.guardian_name"></span>
+                                                <span class="text-gray-500" v-text="g.relation ? '(' + g.relation + ')' : ''"></span>
+                                                — <span v-text="g.mobile_number"></span>
+                                            </li>
+                                        </ul>
+                                        <p class="text-xs text-gray-500 mt-1">You'll be able to review and edit parent details in the next steps.</p>
+                                    </div>
+
+                                    <button
+                                        v-if="existingDetails.can_continue"
+                                        @click="startExistingFlow"
+                                        class="btn-primary w-full"
+                                    >
+                                        Continue Application →
+                                    </button>
+                                    <p v-else class="text-sm text-red-600 text-center">
+                                        This student cannot re-apply online. Please contact the school office.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Step 1: Guardian Information -->
                     <div v-if="currentStep === 1" class="space-y-6">
                         <div class="text-center">
@@ -429,146 +580,23 @@
                         </div>
                     </div>
                     
-                    <!-- Step 3: Student Type Selection -->
+                    <!-- Step 3: Confirm (type chosen on the start page) -->
                     <div v-if="currentStep === 3" class="space-y-6">
                         <div class="text-center">
-                            <h2 class="text-xl font-semibold text-gray-900 mb-4">Student Type</h2>
-                            <p class="text-gray-600">Is this a new student or an existing student?</p>
+                            <h2 class="text-xl font-semibold text-gray-900 mb-4">Confirm</h2>
+                            <p class="text-gray-600">Review your selection before continuing.</p>
                         </div>
-                        
-                        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                            <button
-                                @click="studentType = 'new'"
-                                :class="[
-                                    'relative rounded-lg border p-6 text-left transition-all duration-200',
-                                    studentType === 'new' 
-                                        ? 'border-blue-500 bg-blue-50 text-blue-900' 
-                                        : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
-                                ]"
-                            >
-                                <div class="flex items-center">
-                                    <div class="flex-shrink-0">
-                                        <svg class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                                        </svg>
-                                    </div>
-                                    <div class="ml-4">
-                                        <p class="text-lg font-medium">New Student</p>
-                                        <p class="text-sm text-gray-500">First time applying to our school</p>
-                                    </div>
-                                </div>
-                            </button>
-                            
-                            <button
-                                @click="studentType = 'existing'"
-                                :class="[
-                                    'relative rounded-lg border p-6 text-left transition-all duration-200',
-                                    studentType === 'existing' 
-                                        ? 'border-blue-500 bg-blue-50 text-blue-900' 
-                                        : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
-                                ]"
-                            >
-                                <div class="flex items-center">
-                                    <div class="flex-shrink-0">
-                                        <svg class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                        </svg>
-                                    </div>
-                                    <div class="ml-4">
-                                        <p class="text-lg font-medium">Existing Student</p>
-                                        <p class="text-sm text-gray-500">Already has a school ID</p>
-                                    </div>
-                                </div>
-                            </button>
+                        <div class="bg-gray-50 p-6 rounded-lg space-y-2 text-sm text-gray-800">
+                            <p><strong>Registration Type:</strong> <span v-text="studentType === 'existing' ? 'Existing Student' : 'New Student'"></span></p>
+                            <p v-if="studentType === 'new'"><strong>Branch:</strong> <span v-text="branchSelection === 'M2' ? 'Second Branch (MBS #2)' : 'Main Branch'"></span></p>
+                            <template v-if="studentType === 'existing' && existingDetails">
+                                <p><strong>Student:</strong> <span v-text="existingDetails.student_name"></span></p>
+                                <p><strong>School ID:</strong> <span v-text="existingDetails.custom_school_id"></span></p>
+                                <p><strong>Applying For:</strong> <span v-text="existingDetails.next_program"></span> <span class="text-gray-500">(promoted from <span v-text="existingDetails.current_program"></span>)</span></p>
+                                <p v-if="existingDetails.suggested_section"><strong>Suggested Section:</strong> <span v-text="existingDetails.suggested_section"></span></p>
+                            </template>
                         </div>
-                        
-                        <!-- Branch Selection for New Students -->
-                        <div v-if="studentType === 'new'" class="space-y-4">
-                            <label class="block text-sm font-medium text-gray-700">Select Branch</label>
-                            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                                <button
-                                    @click="branchSelection = 'M1'"
-                                    :class="[
-                                        'relative rounded-lg border p-4 text-left transition-all duration-200',
-                                        branchSelection === 'M1' 
-                                            ? 'border-blue-500 bg-blue-50 text-blue-900' 
-                                            : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
-                                    ]"
-                                >
-                                    <div class="flex items-center">
-                                        <div class="flex-shrink-0">
-                                            <div class="h-8 w-8 rounded-full bg-blue-100 flex items-center justify-center">
-                                                <span class="text-blue-600 font-semibold">M1</span>
-                                            </div>
-                                        </div>
-                                        <div class="ml-3">
-                                            <p class="text-sm font-medium">Main Branch</p>
-                                        </div>
-                                    </div>
-                                </button>
-                                <button
-                                    @click="branchSelection = 'M2'"
-                                    :class="[
-                                        'relative rounded-lg border p-4 text-left transition-all duration-200',
-                                        branchSelection === 'M2' 
-                                            ? 'border-blue-500 bg-blue-50 text-blue-900' 
-                                            : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50'
-                                    ]"
-                                >
-                                    <div class="flex items-center">
-                                        <div class="flex-shrink-0">
-                                            <div class="h-8 w-8 rounded-full bg-green-100 flex items-center justify-center">
-                                                <span class="text-green-600 font-semibold">M2</span>
-                                            </div>
-                                        </div>
-                                        <div class="ml-3">
-                                            <p class="text-sm font-medium">Second Branch</p>
-                                        </div>
-                                    </div>
-                                </button>
-                            </div>
-                        </div>
-                        
-                        <!-- School ID Lookup for Existing Students -->
-                        <div v-if="studentType === 'existing'" class="space-y-4">
-                            <label class="block text-sm font-medium text-gray-700">Enter School ID</label>
-                            <div class="flex space-x-2">
-                                <div class="relative flex-1">
-                            <input 
-                                v-model="existingSchoolId" 
-                                type="text" 
-                                class="input-field" 
-                                placeholder="e.g., M1/10001/19"
-                                        :disabled="isCheckingSchoolId"
-                                        @keydown.enter="lookupStudent"
-                                    >
-                                </div>
-                                <button 
-                                    @click="lookupStudent"
-                                    :disabled="isCheckingSchoolId || !existingSchoolId.trim()"
-                                    :class="[
-                                        'px-4 py-2 rounded-md font-medium transition-colors',
-                                        isCheckingSchoolId || !existingSchoolId.trim() 
-                                            ? 'bg-gray-300 text-gray-500 cursor-not-allowed' 
-                                            : 'bg-blue-600 text-white hover:bg-blue-700'
-                                    ]"
-                                >
-                                    <span v-if="isCheckingSchoolId" class="flex items-center">
-                                        <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
-                                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                        </svg>
-                                        Checking...
-                                    </span>
-                                    <span v-else>Check ID</span>
-                                </button>
-                            </div>
-                            <div v-if="existingStudent" class="bg-green-50 p-4 rounded-lg">
-                                <p class="text-green-800 font-medium">Student Found:</p>
-                                <p class="text-green-700" v-text="existingStudent.first_name + ' ' + (existingStudent.middle_name || '') + ' ' + existingStudent.last_name"></p>
-                            </div>
-                            <div v-if="schoolIdError" class="text-red-600 text-sm" v-text="schoolIdError"></div>
-                        </div>
+                        <p class="text-xs text-gray-500 text-center">To change this, use "Start New Application".</p>
                     </div>
                     
                     <!-- Step 4: Student Details -->
@@ -755,6 +783,7 @@
                                 <div>
                                     <p><strong>Mobile:</strong> <span v-text="studentData.primary_mobile_number"></span></p>
                                     <p><strong>Program:</strong> <span v-text="selectedProgramName"></span></p>
+                                    <p v-if="studentData.custom_school_id"><strong>School ID:</strong> <span class="font-semibold text-blue-700" v-text="studentData.custom_school_id"></span></p>
                                     <p v-if="isNurseryGrade && studentData.birth_certificate_image"><strong>Birth Certificate:</strong> ✓ Uploaded</p>
                                 </div>
                             </div>
@@ -870,6 +899,11 @@
                         </svg>
                     </div>
                     <h3 class="text-lg leading-6 font-medium text-gray-900 mt-2">Application Submitted Successfully!</h3>
+                    <div v-if="generatedSchoolId" class="mx-6 mt-3 mb-1 rounded-lg bg-blue-50 border border-blue-200 py-3">
+                        <p class="text-xs uppercase tracking-wide text-blue-500">Generated Student ID</p>
+                        <p class="text-2xl font-bold text-blue-800" v-text="generatedSchoolId"></p>
+                        <p v-if="submittedBranch" class="text-xs text-blue-600 mt-1">Branch: <span v-text="submittedBranch"></span></p>
+                    </div>
                     <div class="mt-2 px-7 py-3">
                         <p class="text-sm text-gray-500">
                             Your application has been submitted with ID: <strong v-text="submittedApplicationId"></strong>
@@ -924,7 +958,7 @@
         createApp({
             data() {
                 return {
-                    currentStep: 1,
+                    currentStep: 0,
                     totalSteps: 5,
                     loading: true,
                     isSubmitting: false,
@@ -936,6 +970,14 @@
                     schoolIdError: '',
                     showSuccessModal: false,
                     submittedApplicationId: '',
+                    // Generated / recorded School ID shown on preview + success page
+                    generatedSchoolId: '',
+                    submittedBranch: '',
+                    // Start gate: '' (not chosen yet), 'new' or 'existing'
+                    flowChoice: '',
+                    // Rich existing-student profile from get_existing_student_details
+                    existingDetails: null,
+                    isLoadingExistingDetails: false,
                     fatherData: {
                         guardian_name: '',
                         email_address: '',
@@ -1146,13 +1188,8 @@
                                 this.studentData.sub_city &&
                                 this.studentData.kebele
                             );
-                        case 3: // Student Type Selection
-                            if (this.studentType === 'new') {
-                                return this.branchSelection;
-                            } else if (this.studentType === 'existing') {
-                                return this.existingStudent !== null;
-                            }
-                            return false;
+                        case 3: // Confirm (type + branch already chosen on the start gate)
+                            return true;
                         case 4: // Student Details
                             const dateValid = this.calendarType === 'ethiopian' ? 
                                 (this.ethiopianDate && !this.ethiopianDateError) : 
@@ -1357,7 +1394,140 @@
                         this.currentStep--;
                     }
                 },
-                
+
+                // --- Start gate (New vs Existing) ---
+                chooseFlow(choice) {
+                    this.flowChoice = choice;
+                    this.studentType = choice;
+                    // Reset any prior existing-student lookup when switching.
+                    if (choice === 'new') {
+                        this.existingDetails = null;
+                        this.existingStudent = null;
+                        this.schoolIdError = '';
+                    }
+                },
+
+                startNewFlow() {
+                    this.studentType = 'new';
+                    this.currentStep = 1;
+                },
+
+                async lookupExistingStudent() {
+                    const schoolId = (this.existingSchoolId || '').trim();
+                    if (!schoolId) return;
+                    this.isLoadingExistingDetails = true;
+                    this.schoolIdError = '';
+                    this.existingDetails = null;
+                    try {
+                        const response = await fetch('/api/method/education.education.api.get_existing_student_details', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ school_id: schoolId })
+                        });
+                        const data = await response.json();
+                        const details = data.message;
+                        if (!details || !details.found) {
+                            this.schoolIdError = (details && details.message) || 'No existing student found with this School ID.';
+                            return;
+                        }
+                        this.existingDetails = details;
+                    } catch (error) {
+                        console.error('Existing student lookup failed:', error);
+                        this.schoolIdError = 'Could not look up the student. Please try again.';
+                    } finally {
+                        this.isLoadingExistingDetails = false;
+                    }
+                },
+
+                startExistingFlow() {
+                    const d = this.existingDetails;
+                    if (!d || !d.can_continue) return;
+                    this.studentType = 'existing';
+
+                    // Prefill student data (editable in later steps).
+                    this.studentData.first_name = d.first_name || '';
+                    this.studentData.middle_name = d.middle_name || '';
+                    this.studentData.last_name = d.last_name || '';
+                    this.studentData.gender = d.gender || '';
+                    this.studentData.date_of_birth = d.date_of_birth || '';
+                    this.studentData.primary_mobile_number = d.student_mobile_number || '';
+                    this.studentData.program = d.next_program || '';
+                    this.studentData.custom_school_id = d.custom_school_id || '';
+                    this.studentData.image = d.image || '';
+                    this.studentData.address_line_1 = d.address_line_1 || '';
+                    this.studentData.sub_city = d.sub_city || '';
+                    this.studentData.kebele = d.kebele || '';
+                    // Keep the gregorian date path for prefilled existing students.
+                    if (d.date_of_birth) {
+                        this.calendarType = 'gregorian';
+                    }
+
+                    // Prefill guardians (parents editable).
+                    this.prefillGuardiansFromExisting(d.guardians || []);
+
+                    // Keep a reference for submit + preview.
+                    this.existingStudent = {
+                        custom_school_id: d.custom_school_id,
+                        first_name: d.first_name,
+                        middle_name: d.middle_name,
+                        last_name: d.last_name
+                    };
+                    this.currentStep = 1;
+                },
+
+                prefillGuardiansFromExisting(guardians) {
+                    const findByRelation = (rel) => guardians.find(g => (g.relation || '').toLowerCase() === rel);
+                    const father = findByRelation('father');
+                    const mother = findByRelation('mother');
+                    if (father || mother) {
+                        this.guardianType = 'parent';
+                        if (father) this.assignGuardian(this.fatherData, father);
+                        if (mother) this.assignGuardian(this.motherData, mother);
+                    } else if (guardians.length) {
+                        this.guardianType = 'guardian';
+                        this.assignGuardian(this.guardianData, guardians[0]);
+                        this.guardianData.relation = guardians[0].relation || 'Other';
+                    }
+                },
+
+                assignGuardian(target, g) {
+                    target.guardian = g.guardian || '';
+                    target.guardian_name = g.guardian_name || '';
+                    // Stored mobile numbers include +251; the form expects the 9 local digits.
+                    target.mobile_number = (g.mobile_number || '').replace('+251', '');
+                    target.alternate_number = (g.alternate_number || '').replace('+251', '');
+                    target.email_address = g.email_address || '';
+                    target.education = g.education || '';
+                    target.occupation = g.occupation || '';
+                    target.work_address = g.work_address || '';
+                    target.image = g.image || '';
+                },
+
+                // Build full guardian payloads (with editable details) for the
+                // existing-student sync endpoint.
+                buildDetailedGuardians() {
+                    const pack = (data, relation) => ({
+                        guardian: data.guardian || '',
+                        guardian_name: data.guardian_name || '',
+                        relation: relation,
+                        mobile_number: data.mobile_number || '',
+                        alternate_number: data.alternate_number || '',
+                        email_address: data.email_address || '',
+                        education: data.education === 'Other' ? (data.education_other || 'Other') : (data.education || ''),
+                        occupation: data.occupation === 'Other' ? (data.occupation_other || 'Other') : (data.occupation || ''),
+                        work_address: data.work_address || '',
+                        image: data.image || ''
+                    });
+                    const out = [];
+                    if (this.guardianType === 'parent') {
+                        if (this.fatherData.guardian_name) out.push(pack(this.fatherData, 'Father'));
+                        if (this.motherData.guardian_name) out.push(pack(this.motherData, 'Mother'));
+                    } else {
+                        if (this.guardianData.guardian_name) out.push(pack(this.guardianData, this.guardianData.relation || 'Other'));
+                    }
+                    return out;
+                },
+
                 async submitApplication() {
                     // Validate the form first
                     if (!this.validateForm()) {
@@ -1532,36 +1702,67 @@
                             ...this.studentData,
                             custom_school_id: schoolId,
                             applicant_type: this.studentType === 'existing' ? 'Existing' : 'New',
+                            branch: this.studentType === 'new'
+                                ? this.branchSelection
+                                : (this.existingDetails ? this.existingDetails.branch : ''),
                             birth_certificate_image: this.studentData.birth_certificate_image,
                             guardians: guardians,
                             siblings: []
                         };
-                        
-                        // Create application
-                        const applicationResponse = await fetch('/api/method/education.education.api.create_student_application', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({
-                                application_data: applicationData
-                            })
-                        });
-                        
-                        if (!applicationResponse.ok) {
-                            const errorData = await applicationResponse.json();
-                            throw new Error(`Failed to create application: ${errorData.message || errorData.exc || applicationResponse.statusText}`);
-                        }
-                        
-                        const applicationResult = await applicationResponse.json();
-                        
-                        if (applicationResult.message) {
-                            this.submittedApplicationId = applicationResult.message;
-                            this.showSuccessModal = true;
+
+                        if (this.studentType === 'existing') {
+                            // Existing student: sync the Student record + guardians, then
+                            // create a fresh applicant for the promoted grade.
+                            applicationData.program = (this.existingDetails && this.existingDetails.next_program) || this.studentData.program;
+                            applicationData.guardians = this.buildDetailedGuardians();
+                            const existingResponse = await fetch('/api/method/education.education.api.submit_existing_student_application', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ application_data: applicationData })
+                            });
+                            if (!existingResponse.ok) {
+                                const errorData = await existingResponse.json();
+                                throw new Error(`Failed to submit application: ${errorData.message || errorData.exc || existingResponse.statusText}`);
+                            }
+                            const existingResult = await existingResponse.json();
+                            const payload = existingResult.message;
+                            if (payload && payload.name) {
+                                this.submittedApplicationId = payload.name;
+                                this.generatedSchoolId = payload.custom_school_id || schoolId;
+                                this.submittedBranch = payload.branch || '';
+                                this.showSuccessModal = true;
+                            } else {
+                                throw new Error(`Failed to submit application: ${existingResult.exc || 'Unknown error'}`);
+                            }
                         } else {
-                            throw new Error(`Failed to create application: ${applicationResult.exc || 'Unknown error'}`);
+                            // New student (unchanged path)
+                            const applicationResponse = await fetch('/api/method/education.education.api.create_student_application', {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                },
+                                body: JSON.stringify({
+                                    application_data: applicationData
+                                })
+                            });
+
+                            if (!applicationResponse.ok) {
+                                const errorData = await applicationResponse.json();
+                                throw new Error(`Failed to create application: ${errorData.message || errorData.exc || applicationResponse.statusText}`);
+                            }
+
+                            const applicationResult = await applicationResponse.json();
+
+                            if (applicationResult.message) {
+                                this.submittedApplicationId = applicationResult.message;
+                                this.generatedSchoolId = schoolId;
+                                this.submittedBranch = this.branchSelection === 'M2' ? 'MBS #2' : 'Main';
+                                this.showSuccessModal = true;
+                            } else {
+                                throw new Error(`Failed to create application: ${applicationResult.exc || 'Unknown error'}`);
+                            }
                         }
-                        
+
                     } catch (error) {
                         console.error('Error submitting application:', error);
                         
@@ -1803,12 +2004,19 @@
                 
                 resetForm() {
                     this.showSuccessModal = false;
-                    this.currentStep = 1;
+                    this.currentStep = 0;
+                    this.flowChoice = '';
                     this.guardianType = 'parent';
                     this.studentType = 'new';
                     this.branchSelection = 'M1';
                     this.submittedApplicationId = '';
-                    
+                    this.generatedSchoolId = '';
+                    this.submittedBranch = '';
+                    this.existingDetails = null;
+                    this.existingStudent = null;
+                    this.existingSchoolId = '';
+                    this.schoolIdError = '';
+
                     // Reset all form data
                     this.fatherData = {
                         guardian_name: '',
@@ -1900,8 +2108,12 @@
                 addAnotherChild() {
                     // Preserve guardian and address information, only reset student details
                     this.showSuccessModal = false;
-                    this.currentStep = 3; // Start from student type selection step (now step 3)
+                    this.currentStep = 0; // Back to the New/Existing start gate
+                    this.flowChoice = '';
                     this.submittedApplicationId = '';
+                    this.generatedSchoolId = '';
+                    this.submittedBranch = '';
+                    this.existingDetails = null;
                     
                     // Keep guardian type and data intact (don't reset guardian info)
                     // Keep address information intact (sub_city, kebele, address_line_1)

--- a/education/www/paid_applicants.html
+++ b/education/www/paid_applicants.html
@@ -1,0 +1,121 @@
+{% raw %}<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Paid Applicants</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body class="bg-gray-100">
+    <div id="app">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6">
+                <div>
+                    <h1 class="text-2xl font-bold text-gray-900">Paid Applicants</h1>
+                    <p class="text-sm text-gray-500">Applicants who have applied and have Paid enabled.</p>
+                </div>
+                <a href="/student-ids" class="mt-3 sm:mt-0 inline-block text-sm font-medium text-blue-600 hover:text-blue-800">← All Generated IDs</a>
+            </div>
+
+            <!-- Summary tiles -->
+            <div class="grid grid-cols-1 sm:grid-cols-4 gap-3 mb-4">
+                <div class="bg-white rounded-lg shadow p-4">
+                    <p class="text-xs uppercase text-gray-400">Total Paid</p>
+                    <p class="text-2xl font-bold text-green-700">{{ rows.length }}</p>
+                </div>
+                <div v-for="(count, b) in byBranch" :key="b" class="bg-white rounded-lg shadow p-4">
+                    <p class="text-xs uppercase text-gray-400">{{ b }}</p>
+                    <p class="text-2xl font-bold text-gray-800">{{ count }}</p>
+                </div>
+            </div>
+
+            <!-- Filters -->
+            <div class="bg-white rounded-lg shadow p-4 mb-4 grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <input v-model="search" @keydown.enter="load" type="text" placeholder="Search name / School ID / mobile" class="border border-gray-300 rounded-md px-3 py-2 text-sm sm:col-span-2">
+                <select v-model="branch" @change="load" class="border border-gray-300 rounded-md px-3 py-2 text-sm">
+                    <option value="">All Branches</option>
+                    <option value="Main">Main</option>
+                    <option value="MBS #2">MBS #2</option>
+                    <option value="MBS Dembi Dollo">MBS Dembi Dollo</option>
+                </select>
+            </div>
+
+            <div class="bg-white rounded-lg shadow overflow-hidden">
+                <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+                    <span class="text-sm text-gray-600">{{ rows.length }} paid applicant(s)</span>
+                    <button @click="load" class="text-sm bg-blue-600 text-white px-3 py-1.5 rounded-md hover:bg-blue-700">Refresh</button>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full text-sm">
+                        <thead class="bg-gray-50 text-gray-600">
+                            <tr>
+                                <th class="text-left px-4 py-2 font-medium">School ID</th>
+                                <th class="text-left px-4 py-2 font-medium">Name</th>
+                                <th class="text-left px-4 py-2 font-medium">Program</th>
+                                <th class="text-left px-4 py-2 font-medium">Branch</th>
+                                <th class="text-left px-4 py-2 font-medium">Type</th>
+                                <th class="text-left px-4 py-2 font-medium">Status</th>
+                                <th class="text-left px-4 py-2 font-medium">Mobile</th>
+                                <th class="text-left px-4 py-2 font-medium">Registered</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-if="loading"><td colspan="8" class="px-4 py-6 text-center text-gray-400">Loading…</td></tr>
+                            <tr v-else-if="!rows.length"><td colspan="8" class="px-4 py-6 text-center text-gray-400">No paid applicants found.</td></tr>
+                            <tr v-for="r in rows" :key="r.name" class="border-t border-gray-100 hover:bg-gray-50">
+                                <td class="px-4 py-2 font-semibold text-blue-700">{{ r.custom_school_id }}</td>
+                                <td class="px-4 py-2">{{ r.full_name }}</td>
+                                <td class="px-4 py-2">{{ r.program }}</td>
+                                <td class="px-4 py-2">{{ r.branch }}</td>
+                                <td class="px-4 py-2">{{ r.applicant_type }}</td>
+                                <td class="px-4 py-2">{{ r.application_status }}</td>
+                                <td class="px-4 py-2">{{ r.student_mobile_number }}</td>
+                                <td class="px-4 py-2 text-gray-500">{{ (r.creation || '').substring(0, 16) }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <p v-if="error" class="text-red-600 text-sm mt-3">{{ error }}</p>
+        </div>
+    </div>
+
+    <script>
+        const { createApp } = Vue;
+        createApp({
+            data() {
+                return { rows: [], loading: false, error: '', search: '', branch: '' };
+            },
+            computed: {
+                byBranch() {
+                    const out = {};
+                    this.rows.forEach(r => { const b = r.branch || 'Main'; out[b] = (out[b] || 0) + 1; });
+                    return out;
+                }
+            },
+            mounted() { this.load(); },
+            methods: {
+                async load() {
+                    this.loading = true;
+                    this.error = '';
+                    try {
+                        const params = new URLSearchParams({ search: this.search, branch: this.branch });
+                        const response = await fetch('/api/method/education.education.api.get_paid_applicants?' + params.toString(), {
+                            method: 'GET',
+                            headers: { 'Accept': 'application/json' }
+                        });
+                        const data = await response.json();
+                        if (!response.ok) { throw new Error((data && (data.message || data.exc)) || 'Failed to load'); }
+                        this.rows = data.message || [];
+                    } catch (e) {
+                        this.error = 'Could not load records: ' + e.message;
+                    } finally {
+                        this.loading = false;
+                    }
+                }
+            }
+        }).mount('#app');
+    </script>
+</body>
+</html>{% endraw %}

--- a/education/www/paid_applicants.py
+++ b/education/www/paid_applicants.py
@@ -1,0 +1,42 @@
+import frappe
+from frappe import _
+
+# Serve fresh every time; this is a staff dashboard, not a cacheable page.
+no_cache = 1
+
+# Staff roles allowed to view the paid-applicants dashboard.
+ALLOWED_ROLES = {
+    "System Manager",
+    "Academics User",
+    "Education Manager",
+    "DD Student Registrar",
+    "Accounts Manager",
+    "Accounts User",
+}
+
+
+def get_context(context):
+    """Context for the "Paid Applicants" staff dashboard.
+
+    Login required and restricted to the staff roles above.
+    """
+    if frappe.session.user == "Guest":
+        redirect_to = "/paid-applicants"
+        try:
+            if getattr(frappe.local, "request", None) and frappe.local.request.path:
+                redirect_to = frappe.local.request.path
+        except Exception:
+            pass
+        frappe.local.flags.redirect_location = "/login?redirect-to=" + redirect_to
+        raise frappe.Redirect
+
+    if frappe.session.user != "Administrator" and not (ALLOWED_ROLES & set(frappe.get_roles())):
+        frappe.throw(
+            _("You are not permitted to view the Paid Applicants page."),
+            frappe.PermissionError,
+        )
+
+    context.no_cache = 1
+    context.title = "Paid Applicants"
+    context.description = "Applicants who have applied and paid"
+    return context

--- a/education/www/student_ids.html
+++ b/education/www/student_ids.html
@@ -1,0 +1,111 @@
+{% raw %}<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Generated Student IDs</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body class="bg-gray-100">
+    <div id="app">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6">
+                <div>
+                    <h1 class="text-2xl font-bold text-gray-900">Generated Student IDs</h1>
+                    <p class="text-sm text-gray-500">Applicants and their generated School IDs, branch and status.</p>
+                </div>
+                <a href="/paid-applicants" class="mt-3 sm:mt-0 inline-block text-sm font-medium text-blue-600 hover:text-blue-800">View Paid Applicants Dashboard →</a>
+            </div>
+
+            <!-- Filters -->
+            <div class="bg-white rounded-lg shadow p-4 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-3">
+                <input v-model="search" @keydown.enter="load" type="text" placeholder="Search name / School ID / mobile" class="border border-gray-300 rounded-md px-3 py-2 text-sm sm:col-span-2">
+                <select v-model="branch" @change="load" class="border border-gray-300 rounded-md px-3 py-2 text-sm">
+                    <option value="">All Branches</option>
+                    <option value="Main">Main</option>
+                    <option value="MBS #2">MBS #2</option>
+                    <option value="MBS Dembi Dollo">MBS Dembi Dollo</option>
+                </select>
+                <select v-model="applicantType" @change="load" class="border border-gray-300 rounded-md px-3 py-2 text-sm">
+                    <option value="">New &amp; Existing</option>
+                    <option value="New">New</option>
+                    <option value="Existing">Existing</option>
+                </select>
+            </div>
+
+            <div class="bg-white rounded-lg shadow overflow-hidden">
+                <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+                    <span class="text-sm text-gray-600">{{ rows.length }} record(s)</span>
+                    <button @click="load" class="text-sm bg-blue-600 text-white px-3 py-1.5 rounded-md hover:bg-blue-700">Refresh</button>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full text-sm">
+                        <thead class="bg-gray-50 text-gray-600">
+                            <tr>
+                                <th class="text-left px-4 py-2 font-medium">School ID</th>
+                                <th class="text-left px-4 py-2 font-medium">Name</th>
+                                <th class="text-left px-4 py-2 font-medium">Program</th>
+                                <th class="text-left px-4 py-2 font-medium">Branch</th>
+                                <th class="text-left px-4 py-2 font-medium">Type</th>
+                                <th class="text-left px-4 py-2 font-medium">Status</th>
+                                <th class="text-left px-4 py-2 font-medium">Paid</th>
+                                <th class="text-left px-4 py-2 font-medium">Suggested Section</th>
+                                <th class="text-left px-4 py-2 font-medium">Registered</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-if="loading"><td colspan="9" class="px-4 py-6 text-center text-gray-400">Loading…</td></tr>
+                            <tr v-else-if="!rows.length"><td colspan="9" class="px-4 py-6 text-center text-gray-400">No records found.</td></tr>
+                            <tr v-for="r in rows" :key="r.name" class="border-t border-gray-100 hover:bg-gray-50">
+                                <td class="px-4 py-2 font-semibold text-blue-700">{{ r.custom_school_id }}</td>
+                                <td class="px-4 py-2">{{ r.full_name }}</td>
+                                <td class="px-4 py-2">{{ r.program }}</td>
+                                <td class="px-4 py-2">{{ r.branch }}</td>
+                                <td class="px-4 py-2">{{ r.applicant_type }}</td>
+                                <td class="px-4 py-2">{{ r.application_status }}</td>
+                                <td class="px-4 py-2">
+                                    <span :class="r.paid ? 'text-green-700 font-medium' : 'text-gray-400'">{{ r.paid ? 'Paid' : 'Unpaid' }}</span>
+                                </td>
+                                <td class="px-4 py-2">{{ r.suggested_student_section || '—' }}</td>
+                                <td class="px-4 py-2 text-gray-500">{{ (r.creation || '').substring(0, 16) }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <p v-if="error" class="text-red-600 text-sm mt-3">{{ error }}</p>
+        </div>
+    </div>
+
+    <script>
+        const { createApp } = Vue;
+        createApp({
+            data() {
+                return { rows: [], loading: false, error: '', search: '', branch: '', applicantType: '' };
+            },
+            mounted() { this.load(); },
+            methods: {
+                async load() {
+                    this.loading = true;
+                    this.error = '';
+                    try {
+                        const params = new URLSearchParams({ search: this.search, branch: this.branch, applicant_type: this.applicantType });
+                        const response = await fetch('/api/method/education.education.api.get_generated_ids?' + params.toString(), {
+                            method: 'GET',
+                            headers: { 'Accept': 'application/json' }
+                        });
+                        const data = await response.json();
+                        if (!response.ok) { throw new Error((data && (data.message || data.exc)) || 'Failed to load'); }
+                        this.rows = data.message || [];
+                    } catch (e) {
+                        this.error = 'Could not load records: ' + e.message;
+                    } finally {
+                        this.loading = false;
+                    }
+                }
+            }
+        }).mount('#app');
+    </script>
+</body>
+</html>{% endraw %}

--- a/education/www/student_ids.py
+++ b/education/www/student_ids.py
@@ -1,0 +1,43 @@
+import frappe
+from frappe import _
+
+# Serve fresh every time; this is a staff dashboard, not a cacheable page.
+no_cache = 1
+
+# Staff roles allowed to view the generated-IDs dashboard. Membership is pure
+# data - grant/revoke these roles to change who has access.
+ALLOWED_ROLES = {
+    "System Manager",
+    "Academics User",
+    "Education Manager",
+    "DD Student Registrar",
+    "Accounts Manager",
+    "Accounts User",
+}
+
+
+def get_context(context):
+    """Context for the "Generated Student IDs" staff dashboard.
+
+    Login required and restricted to the staff roles above.
+    """
+    if frappe.session.user == "Guest":
+        redirect_to = "/student-ids"
+        try:
+            if getattr(frappe.local, "request", None) and frappe.local.request.path:
+                redirect_to = frappe.local.request.path
+        except Exception:
+            pass
+        frappe.local.flags.redirect_location = "/login?redirect-to=" + redirect_to
+        raise frappe.Redirect
+
+    if frappe.session.user != "Administrator" and not (ALLOWED_ROLES & set(frappe.get_roles())):
+        frappe.throw(
+            _("You are not permitted to view the Generated Student IDs page."),
+            frappe.PermissionError,
+        )
+
+    context.no_cache = 1
+    context.title = "Generated Student IDs"
+    context.description = "Applicants and their generated School IDs"
+    return context


### PR DESCRIPTION
Adds a new-vs-existing student registration flow, branch tracking, promotion
logic, staff dashboards and an accountant notification across the MBReg1825
and Dembi Dollo (apply_dd) application pages.

Schema (fixtures + live via MCP):
- Custom Fields on Student Applicant: `branch` (Main / MBS #2 / MBS Dembi Dollo)
  and read-only `suggested_student_section`.
- New `Not Promoted Student` doctype (school_id, academic_year, program, reason)
  used to decide promotion; students not in it are assumed promoted.

Backend (education/api.py):
- Branch auto-derivation from School ID prefix (MB/DD, M2) + form override.
- Promotion/next-grade computation (Nursery->LKG->UKG->Grade 1..12, AO suffix
  preserved, Grade 11/12 default to NS stream, Grade 12 graduates).
- get_existing_student_details: picture, name, guardians, current grade,
  promotion + restriction status, next program, suggested section.
- submit_existing_student_application: syncs the Student record + guardians in
  place and creates a fresh applicant for the promoted grade.
- Gender-balanced round-robin section suggestion (existing students carry the
  section letter forward).
- Staff endpoints get_generated_ids / get_paid_applicants (role-gated).
- notify_accountants_of_new_applicants: every-30-min cron building a CSV of new
  applicants (split by branch and New/Existing) with a Notification Log to the
  Accounts roles. PDF header now shows School ID + Branch prominently.

Frontend:
- mbreg1825 + apply_dd: start gate (New / Existing), existing-student lookup
  with rich detail + promotion gating + editable parents, generated School ID
  shown on preview and success page.
- New staff pages: /student-ids (generated IDs + status) and /paid-applicants.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0179sBJ7YzYTGC4Niyo8UMUh