### PR TITLE
Simplify Dembi Dollo student application flow

### DIFF
--- a/education/education/api.py
+++ b/education/education/api.py
@@ -3782,6 +3782,52 @@ def get_paid_applicants(search=None, branch=None, limit=200):
     return rows
 
 
+@frappe.whitelist()
+def get_dd_applied_students(search=None, limit=300):
+    """Read-only status list for the /apply-dd page: applicants filed so far
+    for the MBS Dembi Dollo branch, with basic info and payment status.
+
+    Gated the same as the other staff dashboards (includes "DD Student
+    Registrar", so the person filling out the apply-dd form can view it).
+    """
+    _require_staff()
+    filters = {"branch": "MBS Dembi Dollo"}
+
+    or_filters = None
+    if search:
+        search = f"%{search}%"
+        or_filters = {
+            "custom_school_id": ["like", search],
+            "first_name": ["like", search],
+            "middle_name": ["like", search],
+            "last_name": ["like", search],
+            "student_mobile_number": ["like", search],
+        }
+
+    rows = frappe.get_all(
+        "Student Applicant",
+        filters=filters,
+        or_filters=or_filters,
+        fields=["name", "first_name", "middle_name", "last_name", "custom_school_id",
+                "program", "applicant_type", "application_status", "paid",
+                "gender", "student_mobile_number", "date_of_birth", "image",
+                "academic_year", "creation"],
+        order_by="creation desc",
+        limit_page_length=cint(limit) or 300,
+    )
+    today = frappe.utils.getdate()
+    for r in rows:
+        r["full_name"] = " ".join([p for p in [r.get("first_name"), r.get("middle_name"),
+                                                r.get("last_name")] if p])
+        dob = r.get("date_of_birth")
+        if dob:
+            dob = frappe.utils.getdate(dob)
+            r["age"] = today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
+        else:
+            r["age"] = None
+    return rows
+
+
 # ================================================================
 # 30-MINUTE ACCOUNTANT NOTIFICATION (CRON)
 # ================================================================

--- a/education/www/apply_dd.html
+++ b/education/www/apply_dd.html
@@ -183,7 +183,7 @@
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                                 </svg>
                                 <p class="text-lg font-medium">Existing Student</p>
-                                <p class="text-sm text-gray-500">Already has a school ID</p>
+                                <p class="text-sm text-gray-500">Already attends the school (School ID auto-generated)</p>
                             </button>
                         </div>
 
@@ -195,70 +195,17 @@
                             <button @click="startNewFlow" class="btn-primary w-full">Continue as New Student →</button>
                         </div>
 
-                        <!-- Existing Student: school ID lookup + rich detail -->
-                        <div v-if="flowChoice === 'existing'" class="space-y-4 border-t border-gray-200 pt-6">
-                            <label class="block text-sm font-medium text-gray-700">Enter the student's School ID</label>
-                            <div class="flex space-x-2">
-                                <input
-                                    v-model="existingSchoolId"
-                                    type="text"
-                                    class="input-field flex-1"
-                                    placeholder="e.g., MB/DD/12345/19"
-                                    :disabled="isLoadingExistingDetails"
-                                    @keydown.enter="lookupExistingStudent"
-                                >
-                                <button
-                                    @click="lookupExistingStudent"
-                                    :disabled="isLoadingExistingDetails || !existingSchoolId.trim()"
-                                    :class="[
-                                        'px-4 py-2 rounded-md font-medium transition-colors',
-                                        isLoadingExistingDetails || !existingSchoolId.trim() ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-blue-600 text-white hover:bg-blue-700'
-                                    ]"
-                                >
-                                    <span v-if="isLoadingExistingDetails">Checking...</span>
-                                    <span v-else>Fetch Details</span>
-                                </button>
+                        <!-- Existing Student: continue (School ID is auto-generated, same as new) -->
+                        <div v-if="flowChoice === 'existing'" class="border-t border-gray-200 pt-6">
+                            <div class="bg-blue-50 p-4 rounded-lg mb-4">
+                                <p class="text-sm text-blue-800">A new School ID will be generated automatically in the format <strong>MB/DD/#####/19</strong> on submission, the same way it is for new students.</p>
                             </div>
-                            <div v-if="schoolIdError" class="text-red-600 text-sm" v-text="schoolIdError"></div>
+                            <button @click="startExistingFlow" class="btn-primary w-full">Continue as Existing Student →</button>
+                        </div>
 
-                            <div v-if="existingDetails && existingDetails.found" class="rounded-lg border border-gray-200 overflow-hidden">
-                                <div class="bg-gray-50 p-5 flex items-start space-x-4">
-                                    <img v-if="existingDetails.image" :src="existingDetails.image" alt="Student" class="h-24 w-24 rounded-lg object-cover border border-gray-300">
-                                    <div v-else class="h-24 w-24 rounded-lg bg-gray-200 flex items-center justify-center text-gray-400 text-xs">No Photo</div>
-                                    <div class="flex-1">
-                                        <h3 class="text-lg font-semibold text-gray-900" v-text="existingDetails.student_name"></h3>
-                                        <p class="text-sm text-gray-600">School ID: <strong v-text="existingDetails.custom_school_id"></strong></p>
-                                        <p class="text-sm text-gray-600">Phone: <span v-text="existingDetails.student_mobile_number || '—'"></span></p>
-                                        <p class="text-sm text-gray-600">Current Grade: <span v-text="existingDetails.current_program || '—'"></span></p>
-                                        <p class="text-sm text-gray-600">Branch: <span v-text="existingDetails.branch"></span></p>
-                                    </div>
-                                </div>
-                                <div class="p-5 space-y-3">
-                                    <div v-if="existingDetails.is_restricted" class="bg-red-50 border-l-4 border-red-500 p-3 text-sm text-red-800">
-                                        <strong>Restricted:</strong> <span v-text="existingDetails.block_reason"></span>
-                                    </div>
-                                    <div v-else-if="!existingDetails.is_promoted" class="bg-yellow-50 border-l-4 border-yellow-500 p-3 text-sm text-yellow-800">
-                                        <strong>Not Promoted:</strong> <span v-text="existingDetails.block_reason"></span>
-                                    </div>
-                                    <div v-else class="bg-green-50 border-l-4 border-green-500 p-3 text-sm text-green-800">
-                                        <strong>Promoted.</strong> This student will be registered for <strong v-text="existingDetails.next_program"></strong>.
-                                        <span v-if="existingDetails.suggested_section">Suggested section: <strong v-text="existingDetails.suggested_section"></strong>.</span>
-                                    </div>
-                                    <div v-if="existingDetails.guardians && existingDetails.guardians.length" class="text-sm text-gray-700">
-                                        <p class="font-medium mb-1">Parent / Guardian(s) on record:</p>
-                                        <ul class="list-disc ml-5">
-                                            <li v-for="g in existingDetails.guardians" :key="g.guardian">
-                                                <span v-text="g.guardian_name"></span>
-                                                <span class="text-gray-500" v-text="g.relation ? '(' + g.relation + ')' : ''"></span>
-                                                — <span v-text="g.mobile_number"></span>
-                                            </li>
-                                        </ul>
-                                        <p class="text-xs text-gray-500 mt-1">You'll be able to review and edit parent details in the next steps.</p>
-                                    </div>
-                                    <button v-if="existingDetails.can_continue" @click="startExistingFlow" class="btn-primary w-full">Continue Application →</button>
-                                    <p v-else class="text-sm text-red-600 text-center">This student cannot re-apply online. Please contact the school office.</p>
-                                </div>
-                            </div>
+                        <!-- Applied Students (read-only status) -->
+                        <div class="border-t border-gray-200 pt-6 text-center">
+                            <button @click="openAppliedList" class="btn-secondary">View Applied Students Status</button>
                         </div>
                     </div>
 
@@ -537,15 +484,7 @@
                         <div class="bg-gray-50 p-6 rounded-lg space-y-2 text-sm text-gray-800">
                             <p><strong>Registration Type:</strong> <span v-text="studentType === 'existing' ? 'Existing Student' : 'New Student'"></span></p>
                             <p><strong>Branch:</strong> MBS Dembi Dollo</p>
-                            <template v-if="studentType === 'new'">
-                                <p class="text-gray-600">A new School ID (MB/DD/#####/19) will be generated on submission.</p>
-                            </template>
-                            <template v-if="studentType === 'existing' && existingDetails">
-                                <p><strong>Student:</strong> <span v-text="existingDetails.student_name"></span></p>
-                                <p><strong>School ID:</strong> <span v-text="existingDetails.custom_school_id"></span></p>
-                                <p><strong>Applying For:</strong> <span v-text="existingDetails.next_program"></span> <span class="text-gray-500">(promoted from <span v-text="existingDetails.current_program"></span>)</span></p>
-                                <p v-if="existingDetails.suggested_section"><strong>Suggested Section:</strong> <span v-text="existingDetails.suggested_section"></span></p>
-                            </template>
+                            <p class="text-gray-600">A new School ID (MB/DD/#####/19) will be generated on submission.</p>
                         </div>
                         <p class="text-xs text-gray-500 text-center">To change this, use "Start New Application".</p>
                     </div>
@@ -902,6 +841,86 @@
                 </div>
             </div>
         </div>
+
+        <!-- Applied Students Status (read-only) -->
+        <div v-if="showAppliedList" class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-[10000] p-4">
+            <div class="relative mx-auto max-w-5xl bg-white rounded-lg shadow-lg mt-10">
+                <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+                    <div>
+                        <h3 class="text-lg font-semibold text-gray-900">Applied Students — MBS Dembi Dollo</h3>
+                        <p class="text-xs text-gray-500">Read-only status of applications submitted so far.</p>
+                    </div>
+                    <button @click="closeAppliedList" class="text-gray-400 hover:text-gray-600">
+                        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
+                    </button>
+                </div>
+                <div class="px-6 py-4">
+                    <div class="flex flex-col sm:flex-row sm:items-center gap-3 mb-4">
+                        <input v-model="appliedListSearch" @keydown.enter="loadAppliedList" type="text" placeholder="Search name / phone / School ID" class="input-field flex-1">
+                        <button @click="loadAppliedList" class="btn-primary">Search</button>
+                        <span class="text-sm text-gray-500 whitespace-nowrap" v-text="appliedList.length + ' applicant(s)'"></span>
+                    </div>
+                    <div class="overflow-x-auto border border-gray-200 rounded-lg">
+                        <table class="min-w-full text-sm">
+                            <thead class="bg-gray-50 text-gray-600">
+                                <tr>
+                                    <th class="text-left px-4 py-2 font-medium">Name</th>
+                                    <th class="text-left px-4 py-2 font-medium">Phone</th>
+                                    <th class="text-left px-4 py-2 font-medium">Age</th>
+                                    <th class="text-left px-4 py-2 font-medium">Grade Applying</th>
+                                    <th class="text-left px-4 py-2 font-medium">Payment Status</th>
+                                    <th class="text-left px-4 py-2 font-medium"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr v-if="appliedListLoading"><td colspan="6" class="px-4 py-6 text-center text-gray-400">Loading…</td></tr>
+                                <tr v-else-if="!appliedList.length"><td colspan="6" class="px-4 py-6 text-center text-gray-400">No applicants found.</td></tr>
+                                <tr v-for="r in appliedList" :key="r.name" class="border-t border-gray-100 hover:bg-gray-50">
+                                    <td class="px-4 py-2" v-text="r.full_name"></td>
+                                    <td class="px-4 py-2" v-text="r.student_mobile_number || '—'"></td>
+                                    <td class="px-4 py-2" v-text="r.age !== null && r.age !== undefined ? r.age : '—'"></td>
+                                    <td class="px-4 py-2" v-text="r.program"></td>
+                                    <td class="px-4 py-2">
+                                        <span :class="r.paid ? 'text-green-700 bg-green-50 border border-green-200' : 'text-red-700 bg-red-50 border border-red-200'" class="px-2 py-0.5 rounded-full text-xs font-medium" v-text="r.paid ? 'Paid' : 'Not Paid'"></span>
+                                    </td>
+                                    <td class="px-4 py-2 text-right">
+                                        <button @click="viewAppliedDetail(r)" class="text-blue-600 hover:text-blue-800 text-sm font-medium">More Details</button>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p v-if="appliedListError" class="text-red-600 text-sm mt-3" v-text="appliedListError"></p>
+                </div>
+            </div>
+
+            <!-- Detail sub-modal -->
+            <div v-if="appliedListDetail" class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-[10001] p-4" @click.self="appliedListDetail = null">
+                <div class="bg-white rounded-lg shadow-lg max-w-lg w-full p-6">
+                    <div class="flex items-start space-x-4 mb-4">
+                        <img v-if="appliedListDetail.image" :src="appliedListDetail.image" class="h-20 w-20 rounded-lg object-cover border border-gray-300">
+                        <div v-else class="h-20 w-20 rounded-lg bg-gray-200 flex items-center justify-center text-gray-400 text-xs">No Photo</div>
+                        <div class="flex-1">
+                            <h4 class="text-lg font-semibold text-gray-900" v-text="appliedListDetail.full_name"></h4>
+                            <p class="text-sm text-gray-500">School ID: <strong v-text="appliedListDetail.custom_school_id || '—'"></strong></p>
+                        </div>
+                    </div>
+                    <div class="grid grid-cols-2 gap-3 text-sm text-gray-700">
+                        <p><strong>Gender:</strong> <span v-text="appliedListDetail.gender || '—'"></span></p>
+                        <p><strong>Age:</strong> <span v-text="appliedListDetail.age !== null && appliedListDetail.age !== undefined ? appliedListDetail.age : '—'"></span></p>
+                        <p><strong>Grade:</strong> <span v-text="appliedListDetail.program || '—'"></span></p>
+                        <p><strong>Type:</strong> <span v-text="appliedListDetail.applicant_type || '—'"></span></p>
+                        <p><strong>Phone:</strong> <span v-text="appliedListDetail.student_mobile_number || '—'"></span></p>
+                        <p><strong>Status:</strong> <span v-text="appliedListDetail.application_status || '—'"></span></p>
+                        <p class="col-span-2"><strong>Payment:</strong>
+                            <span :class="appliedListDetail.paid ? 'text-green-700' : 'text-red-700'" class="font-medium" v-text="appliedListDetail.paid ? 'Paid' : 'Not Paid'"></span>
+                        </p>
+                        <p class="col-span-2"><strong>Applied On:</strong> <span v-text="(appliedListDetail.creation || '').substring(0, 16)"></span></p>
+                    </div>
+                    <button @click="appliedListDetail = null" class="btn-secondary w-full mt-4">Close</button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <script>
@@ -921,16 +940,17 @@
                     isSubmitting: false,
                     guardianType: 'parent',
                     studentType: 'new',
-                    existingSchoolId: '',
-                    schoolIdError: '',
                     flowChoice: '',
-                    existingDetails: null,
-                    isLoadingExistingDetails: false,
                     generatedSchoolId: '',
                     submittedBranch: '',
-                    existingStudent: null,
                     showSuccessModal: false,
                     submittedApplicationId: '',
+                    showAppliedList: false,
+                    appliedListLoading: false,
+                    appliedListError: '',
+                    appliedList: [],
+                    appliedListSearch: '',
+                    appliedListDetail: null,
                     fatherData: {
                         guardian_name: '',
                         email_address: '',
@@ -1305,14 +1325,13 @@
                 },
 
                 // --- Start gate (New vs Existing) ---
+                // Both choices lead to the same form: Dembi Dollo has no School
+                // IDs on file yet, so "Existing Student" no longer looks one up -
+                // it just tags the application and generates a fresh ID on submit,
+                // exactly like "New Student" does.
                 chooseFlow(choice) {
                     this.flowChoice = choice;
                     this.studentType = choice;
-                    if (choice === 'new') {
-                        this.existingDetails = null;
-                        this.existingStudent = null;
-                        this.schoolIdError = '';
-                    }
                 },
 
                 startNewFlow() {
@@ -1320,123 +1339,47 @@
                     this.currentStep = 1;
                 },
 
-                async lookupExistingStudent() {
-                    const schoolId = (this.existingSchoolId || '').trim();
-                    if (!schoolId) return;
-                    this.isLoadingExistingDetails = true;
-                    this.schoolIdError = '';
-                    this.existingDetails = null;
-                    try {
-                        const response = await fetch('/api/method/education.education.api.get_existing_student_details', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ school_id: schoolId })
-                        });
-                        const data = await response.json();
-                        const details = data.message;
-                        if (!details || !details.found) {
-                            this.schoolIdError = (details && details.message) || 'No existing student found with this School ID.';
-                            return;
-                        }
-                        this.existingDetails = details;
-                    } catch (error) {
-                        console.error('Existing student lookup failed:', error);
-                        this.schoolIdError = 'Could not look up the student. Please try again.';
-                    } finally {
-                        this.isLoadingExistingDetails = false;
-                    }
-                },
-
                 startExistingFlow() {
-                    const d = this.existingDetails;
-                    if (!d || !d.can_continue) return;
                     this.studentType = 'existing';
-                    this.studentData.first_name = d.first_name || '';
-                    this.studentData.middle_name = d.middle_name || '';
-                    this.studentData.last_name = d.last_name || '';
-                    this.studentData.gender = d.gender || '';
-                    this.studentData.date_of_birth = d.date_of_birth || '';
-                    this.studentData.primary_mobile_number = this.normalizePhone(d.student_mobile_number);
-                    this.studentData.program = d.next_program || '';
-                    this.studentData.custom_school_id = d.custom_school_id || '';
-                    this.studentData.image = d.image || '';
-                    this.studentData.address_line_1 = d.address_line_1 || '';
-                    // Populate the kebele options for the prefilled sub-city *without*
-                    // clearing the kebele (onSubCityChange resets it, so it can't be used here).
-                    this.studentData.sub_city = d.sub_city || '';
-                    this.availableKebeles = this.kebeleSubCityData[this.studentData.sub_city] || [];
-                    this.studentData.kebele = d.kebele || '';
-                    if (d.date_of_birth && this.hasOwnProperty('calendarType')) {
-                        this.calendarType = 'gregorian';
-                    }
-                    this.prefillGuardiansFromExisting(d.guardians || []);
-                    this.existingStudent = {
-                        custom_school_id: d.custom_school_id,
-                        first_name: d.first_name,
-                        middle_name: d.middle_name,
-                        last_name: d.last_name
-                    };
                     this.currentStep = 1;
                 },
 
-                // Normalise a stored number to the +251XXXXXXXXX form the
-                // Primary Mobile Number options use, so the prefilled value
-                // matches an option instead of rendering blank.
-                normalizePhone(value) {
-                    const digits = (value || '').replace(/\D/g, '');
-                    if (!digits) return '';
-                    const local = digits.slice(-9);
-                    return local ? ('+251' + local) : '';
+                // --- Applied Students Status (read-only) ---
+                openAppliedList() {
+                    this.showAppliedList = true;
+                    this.appliedListDetail = null;
+                    this.loadAppliedList();
                 },
 
-                prefillGuardiansFromExisting(guardians) {
-                    const findByRelation = (rel) => guardians.find(g => (g.relation || '').toLowerCase() === rel);
-                    const father = findByRelation('father');
-                    const mother = findByRelation('mother');
-                    if (father || mother) {
-                        this.guardianType = 'parent';
-                        if (father) this.assignGuardian(this.fatherData, father);
-                        if (mother) this.assignGuardian(this.motherData, mother);
-                    } else if (guardians.length) {
-                        this.guardianType = 'guardian';
-                        this.assignGuardian(this.guardianData, guardians[0]);
-                        this.guardianData.relation = guardians[0].relation || 'Other';
+                closeAppliedList() {
+                    this.showAppliedList = false;
+                    this.appliedListDetail = null;
+                },
+
+                async loadAppliedList() {
+                    this.appliedListLoading = true;
+                    this.appliedListError = '';
+                    try {
+                        const params = new URLSearchParams({ search: this.appliedListSearch || '' });
+                        const response = await fetch('/api/method/education.education.api.get_dd_applied_students?' + params.toString(), {
+                            method: 'GET',
+                            headers: { 'Accept': 'application/json' }
+                        });
+                        const data = await response.json();
+                        if (!response.ok) {
+                            throw new Error((data && (data.message || data.exc)) || 'Failed to load applicants');
+                        }
+                        this.appliedList = data.message || [];
+                    } catch (error) {
+                        console.error('Failed to load applied students:', error);
+                        this.appliedListError = 'Could not load applicants: ' + error.message;
+                    } finally {
+                        this.appliedListLoading = false;
                     }
                 },
 
-                assignGuardian(target, g) {
-                    target.guardian = g.guardian || '';
-                    target.guardian_name = g.guardian_name || '';
-                    target.mobile_number = (g.mobile_number || '').replace('+251', '');
-                    target.alternate_number = (g.alternate_number || '').replace('+251', '');
-                    target.email_address = g.email_address || '';
-                    target.education = g.education || '';
-                    target.occupation = g.occupation || '';
-                    target.work_address = g.work_address || '';
-                    target.image = g.image || '';
-                },
-
-                buildDetailedGuardians() {
-                    const pack = (data, relation) => ({
-                        guardian: data.guardian || '',
-                        guardian_name: data.guardian_name || '',
-                        relation: relation,
-                        mobile_number: data.mobile_number || '',
-                        alternate_number: data.alternate_number || '',
-                        email_address: data.email_address || '',
-                        education: data.education === 'Other' ? (data.education_other || 'Other') : (data.education || ''),
-                        occupation: data.occupation === 'Other' ? (data.occupation_other || 'Other') : (data.occupation || ''),
-                        work_address: data.work_address || '',
-                        image: data.image || ''
-                    });
-                    const out = [];
-                    if (this.guardianType === 'parent') {
-                        if (this.fatherData.guardian_name) out.push(pack(this.fatherData, 'Father'));
-                        if (this.motherData.guardian_name) out.push(pack(this.motherData, 'Mother'));
-                    } else {
-                        if (this.guardianData.guardian_name) out.push(pack(this.guardianData, this.guardianData.relation || 'Other'));
-                    }
-                    return out;
+                viewAppliedDetail(row) {
+                    this.appliedListDetail = row;
                 },
 
                 async submitApplication() {
@@ -1562,40 +1505,36 @@
                             }
                         }
                         
-                        // Handle school ID based on student type
+                        // Auto-generate a new Dembi Dollo school ID: MB/DD/#####/19.
+                        // Both New and Existing students get a freshly generated ID here -
+                        // Dembi Dollo has no School IDs on file yet for its existing
+                        // students, so there is nothing to look up.
+                        const schoolIdResponse = await fetch('/api/method/education.education.api.generate_dd_school_id', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({})
+                        });
+
+                        if (!schoolIdResponse.ok) {
+                            const errorData = await schoolIdResponse.json();
+                            throw new Error(`Failed to generate school ID: ${errorData.message || errorData.exc || schoolIdResponse.statusText}`);
+                        }
+
+                        const schoolIdData = await schoolIdResponse.json();
                         let schoolId = '';
-                        let studentEmailId = '';
-                        if (this.studentType === 'new') {
-                            // Auto-generate a new Dembi Dollo school ID: MB/DD/#####/19
-                            const schoolIdResponse = await fetch('/api/method/education.education.api.generate_dd_school_id', {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                },
-                                body: JSON.stringify({})
-                            });
-
-                            if (!schoolIdResponse.ok) {
-                                const errorData = await schoolIdResponse.json();
-                                throw new Error(`Failed to generate school ID: ${errorData.message || errorData.exc || schoolIdResponse.statusText}`);
-                            }
-
-                            const schoolIdData = await schoolIdResponse.json();
-                            if (schoolIdData.message) {
-                                schoolId = schoolIdData.message;
-                            } else {
-                                throw new Error(`Failed to get school ID: ${schoolIdData.exc || 'Unknown error'}`);
-                            }
-                        } else if (this.studentType === 'existing') {
-                            // Use the canonical School ID fetched from the Student record.
-                            schoolId = (this.existingDetails && this.existingDetails.custom_school_id) || this.existingSchoolId.trim();
+                        if (schoolIdData.message) {
+                            schoolId = schoolIdData.message;
+                        } else {
+                            throw new Error(`Failed to get school ID: ${schoolIdData.exc || 'Unknown error'}`);
                         }
 
                         // Prepare application data
                         const applicationData = {
                             ...this.studentData,
                             custom_school_id: schoolId,
-                            student_email_id: studentEmailId,
+                            student_email_id: '',
                             applicant_type: this.studentType === 'existing' ? 'Existing' : 'New',
                             branch: 'MBS Dembi Dollo',
                             birth_certificate_image: this.studentData.birth_certificate_image,
@@ -1603,57 +1542,32 @@
                             siblings: []
                         };
 
-                        if (this.studentType === 'existing') {
-                            // Existing student: sync the Student record + guardians, then
-                            // create a fresh applicant for the promoted grade.
-                            applicationData.program = (this.existingDetails && this.existingDetails.next_program) || this.studentData.program;
-                            applicationData.guardians = this.buildDetailedGuardians();
-                            const existingResponse = await fetch('/api/method/education.education.api.submit_existing_student_application', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ application_data: applicationData })
-                            });
-                            if (!existingResponse.ok) {
-                                const errorData = await existingResponse.json();
-                                throw new Error(`Failed to submit application: ${errorData.message || errorData.exc || existingResponse.statusText}`);
-                            }
-                            const existingResult = await existingResponse.json();
-                            const payload = existingResult.message;
-                            if (payload && payload.name) {
-                                this.submittedApplicationId = payload.name;
-                                this.generatedSchoolId = payload.custom_school_id || schoolId;
-                                this.submittedBranch = payload.branch || 'MBS Dembi Dollo';
-                                this.showSuccessModal = true;
-                            } else {
-                                throw new Error(`Failed to submit application: ${existingResult.exc || 'Unknown error'}`);
-                            }
+                        // Create application (New and Existing both file a fresh
+                        // Student Applicant record against the newly generated ID)
+                        const applicationResponse = await fetch('/api/method/education.education.api.create_student_application', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({
+                                application_data: applicationData
+                            })
+                        });
+
+                        if (!applicationResponse.ok) {
+                            const errorData = await applicationResponse.json();
+                            throw new Error(`Failed to create application: ${errorData.message || errorData.exc || applicationResponse.statusText}`);
+                        }
+
+                        const applicationResult = await applicationResponse.json();
+
+                        if (applicationResult.message) {
+                            this.submittedApplicationId = applicationResult.message;
+                            this.generatedSchoolId = schoolId;
+                            this.submittedBranch = 'MBS Dembi Dollo';
+                            this.showSuccessModal = true;
                         } else {
-                            // Create application (new student)
-                            const applicationResponse = await fetch('/api/method/education.education.api.create_student_application', {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                },
-                                body: JSON.stringify({
-                                    application_data: applicationData
-                                })
-                            });
-
-                            if (!applicationResponse.ok) {
-                                const errorData = await applicationResponse.json();
-                                throw new Error(`Failed to create application: ${errorData.message || errorData.exc || applicationResponse.statusText}`);
-                            }
-
-                            const applicationResult = await applicationResponse.json();
-
-                            if (applicationResult.message) {
-                                this.submittedApplicationId = applicationResult.message;
-                                this.generatedSchoolId = schoolId;
-                                this.submittedBranch = 'MBS Dembi Dollo';
-                                this.showSuccessModal = true;
-                            } else {
-                                throw new Error(`Failed to create application: ${applicationResult.exc || 'Unknown error'}`);
-                            }
+                            throw new Error(`Failed to create application: ${applicationResult.exc || 'Unknown error'}`);
                         }
 
                     } catch (error) {
@@ -1901,10 +1815,6 @@
                     this.flowChoice = '';
                     this.guardianType = 'parent';
                     this.studentType = 'new';
-                    this.existingSchoolId = '';
-                    this.schoolIdError = '';
-                    this.existingDetails = null;
-                    this.existingStudent = null;
                     this.generatedSchoolId = '';
                     this.submittedBranch = '';
                     this.submittedApplicationId = '';
@@ -2001,11 +1911,10 @@
                     this.showSuccessModal = false;
                     this.currentStep = 0; // Back to the New/Existing start gate
                     this.flowChoice = '';
-                    this.existingDetails = null;
                     this.generatedSchoolId = '';
                     this.submittedBranch = '';
                     this.submittedApplicationId = '';
-                    
+
                     // Keep guardian type and data intact (don't reset guardian info)
                     // Keep address information intact (sub_city, kebele, address_line_1)
                     
@@ -2026,8 +1935,7 @@
                     
                     // Reset student type for new student
                     this.studentType = 'new';
-                    this.existingSchoolId = '';
-                    
+
                     // Reset validation errors
                     this.validationErrors = {};
                     


### PR DESCRIPTION
## Summary
Simplified the student application process for MBS Dembi Dollo by removing the existing student lookup feature and unifying both "New Student" and "Existing Student" paths to use the same form with auto-generated School IDs. Added a read-only "Applied Students Status" view for staff to monitor submissions.

## Key Changes

- **Removed existing student School ID lookup**: Eliminated the manual School ID entry and lookup flow that fetched student details from the database. Since Dembi Dollo has no pre-existing School IDs on file, this lookup was unnecessary.

- **Unified application flow**: Both "New Student" and "Existing Student" now follow the same form and both receive auto-generated School IDs (MB/DD/#####/19) on submission. The only difference is the `applicant_type` field ("New" vs "Existing").

- **Simplified submission logic**: Removed the separate `submit_existing_student_application` endpoint call and related guardian prefilling logic. All applications now use the standard `create_student_application` endpoint.

- **Added Applied Students Status view**: New read-only modal (`showAppliedList`) that displays all applicants filed for Dembi Dollo with:
  - Searchable table of applicants (by name, phone, School ID)
  - Key fields: name, phone, age, grade, payment status
  - Expandable detail view for each applicant
  - Gated behind staff permissions (same as other dashboards)

- **Updated UI messaging**: Changed "Existing Student" description from "Already has a school ID" to "Already attends the school (School ID auto-generated)" to clarify the new behavior.

## Implementation Details

- Removed Vue data properties: `existingSchoolId`, `schoolIdError`, `existingDetails`, `isLoadingExistingDetails`, `existingStudent`
- Added Vue data properties: `showAppliedList`, `appliedListLoading`, `appliedListError`, `appliedList`, `appliedListSearch`, `appliedListDetail`
- Removed methods: `lookupExistingStudent`, `normalizePhone`, `prefillGuardiansFromExisting`, `assignGuardian`, `buildDetailedGuardians`
- Added methods: `openAppliedList`, `closeAppliedList`, `loadAppliedList`, `viewAppliedDetail`
- Added backend API endpoint: `get_dd_applied_students()` for fetching applicant list with search and age calculation
- Confirmation step now shows unified messaging for both student types

https://claude.ai/code/session_018naaQmCoCxtRLt7DpGeYgZ